### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/abstractfactory/pyblish.png?label=ready&title=Ready)](https://waffle.io/abstractfactory/pyblish)
 ### ![][logo]
 
 [![Build Status][travis]][travis_repo]


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/abstractfactory/pyblish

This was requested by a real person (user mottosso) on waffle.io, we're not trying to spam you.
