### PR TITLE
1.0.9 - Requires

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ dist
 *.pyc
 cover
 .coverage
-docs/_**
+docs/_*
 build
 playground.py

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cover
 docs/_*
 build
 playground.py
+*.sublime-*

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,19 @@ pyblish Changelog
 
 This contains all major version changes between pyblish releases.
 
+Version 1.0.9
+-------------
+
+- Requires. Plug-ins may now specify a version with which they
+    are compatible with, using [iscompatible][] which is a
+    requirements.txt-like syntax for dependency specifications.
+- Improved logging, including visualisation of which instance
+    is currently being processed by each plug-in.
+- iscompatible is now included in /vendor
+
+[iscompatible]: https://github.com/mottosso/iscompatible
+
+
 Version 1.0.8
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,7 +84,7 @@ Exceptions raised that are specific to Pyblish.
 Context
 -------
 
-The context is a container of one or more instances along with metadata to describe them all; such as the current working directory or logged on user.
+The context is a container of one or more objects of type :class:`Instance` along with metadata to describe them all; such as the current working directory or logged on user.
 
 .. autoclass:: Context
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Central objects used throughout Pyblish.
 .. autosummary::
     :nosignatures:
 
+    AbstractEntity
     Context
     Instance
     Plugin
@@ -80,6 +81,16 @@ Exceptions raised that are specific to Pyblish.
 
 .. module:: pyblish.plugin
 
+
+AbstractEntity
+--------------
+
+Superclass to Context and Instance, providing the data plug-in to plug-in
+API via the data member.
+
+.. autoclass:: AbstractEntity
+    :members:
+    :undoc-members:
 
 Context
 -------

--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -1,7 +1,11 @@
 import os
-import sys
 import re
+import sys
 import logging
+
+_filename_ascii_strip_re = re.compile(r'[^-\w.]')
+_windows_device_files = ('CON', 'AUX', 'COM1', 'COM2', 'COM3', 'COM4',
+                         'LPT1', 'LPT2', 'LPT3', 'PRN', 'NUL')
 
 
 def log(cls):
@@ -40,18 +44,16 @@ def parse_environment_paths(paths):
 
     paths_list = list()
 
-    sep = ';' if os.name == 'nt' else ':'
-
-    for path in paths.split(sep):
+    for path in paths.split(os.pathsep):
         paths_list.append(path)
 
     return paths_list
 
 
 def format_filename(filename):
-    """Convert arbitrary string to valid filename
+    """Convert arbitrary string to valid filename, django-style.
 
-    Modified copy from django.utils.text.get_valid_filename()
+    Modified from django.utils.text.get_valid_filename()
 
     Returns the given string converted to a string that can be used for a clean
     filename. Specifically, leading and trailing spaces are removed; other
@@ -69,7 +71,67 @@ def format_filename(filename):
     """
 
     filename = filename.strip().replace(' ', '_')
+
+    # on nt a couple of special files are present in each folder.  We
+    # have to ensure that the target file is not such a filename.  In
+    # this case we prepend an underline
+    if os.name == 'nt' and filename and \
+       filename.split('.')[0].upper() in _windows_device_files:
+        filename = '_' + filename
+
     return re.sub(r'(?u)[^-\w.]', '', filename)
+
+
+def format_filename2(filename):
+    """Convert arbitrary string to valid filename, werkzeug-style.
+
+    Modifier from werkzeug.utils.secure_filename()
+
+    Pass it a filename and it will return a secure version of it.  This
+    filename can then safely be stored on a regular file system and passed
+    to :func:`os.path.join`.  The filename returned is an ASCII only string
+    for maximum portability.secure_fil
+
+    On windows system the function also makes sure that the file is not
+    named after one of the special device files.
+
+    Arguments:
+        filename (str): the filename to secure
+
+    Usage:
+        >>> format_filename2("john's portrait in 2004.jpg")
+        'johns_portrait_in_2004.jpg'
+        >>> format_filename2("something^_SD.dda.//fd/ad.exe")
+        'something_SD.dda._fd_ad.exe'
+        >>> format_filename2("Napoleon_:namespaces_GRP|group1_GRP")
+        'Napoleon_namespaces_GRPgroup1_GRP'
+
+    .. warning:: The function might return an empty filename.  It's your
+        responsibility to ensure that the filename is unique and that you
+        generate random filename if the function returned an empty one.
+
+    .. versionadded:: 1.0.9
+
+    """
+
+    if isinstance(filename, unicode):
+        from unicodedata import normalize
+        filename = normalize('NFKD', filename).encode('ascii', 'ignore')
+
+    for sep in os.path.sep, os.path.altsep:
+        if sep:
+            filename = filename.replace(sep, ' ')
+    filename = str(_filename_ascii_strip_re.sub('', '_'.join(
+                   filename.split()))).strip('._')
+
+    # on nt a couple of special files are present in each folder.  We
+    # have to ensure that the target file is not such a filename.  In
+    # this case we prepend an underline
+    if os.name == 'nt' and filename and \
+       filename.split('.')[0].upper() in _windows_device_files:
+        filename = '_' + filename
+
+    return filename
 
 
 def get_formatter():

--- a/pyblish/main.py
+++ b/pyblish/main.py
@@ -26,8 +26,22 @@ TAB = "    "
 LOG_TEMPATE = "    %(levelname)-8s %(message)s"
 SCREEN_WIDTH = 80
 
-logging_handlers = logging.getLogger().handlers[:]
-log = logging.getLogger('pyblish.main')
+# Messages
+NO_INSTANCES_ERROR = "Cancelled due to not finding any instances"
+SELECTION_ERROR = "Selection failed"
+VALIDATION_ERROR = "Validation failed"
+
+# Templates
+AUTO_REPAIR = "There were errors, attempting to auto-repair.."
+COMMITTED_TEMPLATE = "{tab}Committed to: {dir}"
+CONFORMED_TEMPLATE = "{tab}Conformed to: {dir}"
+FAILED_VALIDATION_TEMPLATE = "{tab}- \"{instance}\": {exception} ({plugin})"
+SUCCESS_TEMPLATE = "Processed {num} instance{s} {status} in {seconds}s"
+TRACEBACK_TEMPLATE = "(Line {line} in \"{file}\" @ \"{func}\")"
+ERROR_TEMPLATE = "{tab}{instance}: {error} {traceback}"
+VALIDATIONS_FAILED_TEMPLATE = """
+These validations failed:
+{failures}"""
 
 __all__ = ['select',
            'validate',
@@ -35,33 +49,6 @@ __all__ = ['select',
            'conform',
            'publish',
            'publish_all']
-
-
-def _format_paths(paths):
-    """Return paths at one new each"""
-    message = ''
-    for path in paths:
-        message += "{0}- {1}\n".format(TAB, path)
-    return message[:-1]  # Discard last newline
-
-
-def _format_plugins(plugins):
-    message = ''
-    for plugin in sorted(plugins, key=lambda p: p.__name__):
-        line = "{tab}- {plug}".format(
-            tab=TAB, plug=plugin.__name__)
-
-        if hasattr(plugin, 'families'):
-            line = line.ljust(50) + " "
-            for family in plugin.families:
-                line += "%s, " % family
-            line = line[:-2]
-
-        line += "\n"
-
-        message += line
-
-    return message[:-1]
 
 
 def publish(context=None,
@@ -189,27 +176,30 @@ class Publish(object):
 
         log_summary = False
 
+        # Initialise pretty-printing for plug-ins
+        self._init_log()
+
         try:
             for order in self.orders:
                 self.process_order(order)
 
         except pyblish.api.NoInstancesError as exc:
-            self.log.warning("Cancelled due to not finding any instances")
+            self.log.warning(NO_INSTANCES_ERROR)
 
         except pyblish.api.SelectionError:
-            self.log.error("Selection failed")
+            self.log.error(SELECTION_ERROR)
 
         except pyblish.api.ValidationError as exc:
-            self.log.error("Validation failed")
+            self.log.error(VALIDATION_ERROR)
 
-            print  # newline
-            print "These validations failed:"
+            failures = list()
             for error in exc.errors:
-                print "{tab}- \"{inst}\": {exc} ({plug})".format(
-                    inst=error.instance,
+                failures.append(FAILED_VALIDATION_TEMPLATE.format(
+                    instance=error.instance,
                     tab=TAB,
-                    exc=error,
-                    plug=error.plugin.__name__)
+                    exception=error,
+                    plugin=error.plugin.__name__))
+            print VALIDATIONS_FAILED_TEMPLATE.format(failures=failures)
 
         except Exception as exc:
             self.log.error("Unhandled exception: %s" % exc)
@@ -226,20 +216,11 @@ class Publish(object):
 
         self._log_time()
 
-        # Revert to a simpler handler
-        logging.getLogger().handlers[:] = []
-
-        formatter = logging.Formatter("%(levelname)s - %(message)s")
-
-        stream_handler = logging.StreamHandler()
-        stream_handler.setFormatter(formatter)
-        logging.getLogger().addHandler(stream_handler)
-
         if log_summary:
             self._log_summary()
-        self._log_success()
 
         self._reset_log()
+        self._log_success()
 
     def process_order(self, order):
         """Process context using plug-ins with the specified `order`
@@ -308,10 +289,11 @@ class Publish(object):
 
         self._log_plugin(plugin)
 
-        # Initialise pretty-printing for plug-ins
-        self._init_log()
-
         for instance, error in plugin().process(self.context):
+            if instance is None:
+                self.log.debug("Skipped, no compatible instances.")
+                continue
+
             if error is None:
                 continue
 
@@ -333,14 +315,13 @@ class Publish(object):
 
     def _repair(self, plugin, instance):
         if hasattr(plugin, 'repair_instance'):
-            self.log.warning("There were errors, attempting "
-                             "to auto-repair..")
+            self.log.warning(AUTO_REPAIR)
             try:
                 plugin().repair_instance(instance)
 
             except Exception as err:
                 self.log.warning("Could not auto-repair..")
-                self.log.warning(err)
+                self._log_error(instance, err)
 
             else:
                 self.log.info("Auto-repair successful")
@@ -349,7 +330,7 @@ class Publish(object):
         return False
 
     def _init_log(self):
-        self.log = logging.getLogger()
+        self.log._handlers = list(self.log.handlers)
         self.log.handlers[:] = []
 
         formatter = logging.Formatter(LOG_TEMPATE)
@@ -361,8 +342,7 @@ class Publish(object):
         self.log.setLevel(self.logging_level)
 
     def _reset_log(self):
-        self.log = logging.getLogger()
-        self.log.handlers[:] = logging_handlers[:]
+        self.log.handlers[:] = self.log._handlers
         self.log.setLevel(logging.INFO)
 
     def _log_plugin(self, plugin, suffix=''):
@@ -433,16 +413,15 @@ Available plugins:
 
         if traceback:
             fname, line_number, func, exc = traceback
-            traceback = ("(Line {line} in \"{file}\" "
-                         "@ \"{func}\")".format(line=line_number,
-                                                file=fname,
-                                                func=func))
+            traceback = (TRACEBACK_TEMPLATE.format(line=line_number,
+                                                   file=fname,
+                                                   func=func))
 
-        self.log.error("{tab}{i}: {e} {tb}".format(
+        self.log.error(ERROR_TEMPLATE.format(
             tab=TAB,
-            i=instance,
-            e=error,
-            tb=traceback if traceback else ''))
+            instance=instance,
+            error=error,
+            traceback=traceback if traceback else ''))
 
     def _log_time(self):
         """Return time-taken message"""
@@ -472,8 +451,7 @@ Available plugins:
 
         num_processed_instances = len(processed_instances)
         (self.log.warning if self._errors else self.log.info)(
-            "Processed {num} instance{s} {status} "
-            "in {seconds}s".format(
+            SUCCESS_TEMPLATE.format(
                 num=num_processed_instances,
                 s="s" if num_processed_instances > 1 else "",
                 status=status,
@@ -487,7 +465,7 @@ Available plugins:
             is_processed = instance.data('__is_processed__')
             processed_by = instance.data('__processed_by__')
             commit_dir = instance.data('commit_dir')
-            conform_dirs = instance.data('conform_dirs')
+            conform_dir = instance.data('conform_dir')
 
             _message = "{tab}- \"{inst}\" ".format(
                 tab=TAB,
@@ -506,12 +484,12 @@ Available plugins:
             message += _message + "\n"
 
             if commit_dir:
-                message += "{tab}Committed to: {dir}".format(
+                message += COMMITTED_TEMPLATE.format(
                     tab=TAB*2, dir=commit_dir) + "\n"
 
-            if conform_dirs:
-                message += "{tab}Conformed to: {dir}".format(
-                    tab=TAB*2, dir=", ".join(conform_dirs)) + "\n"
+            if conform_dir:
+                message += CONFORMED_TEMPLATE.format(
+                    tab=TAB*2, dir=conform_dir) + "\n"
 
         print  # newline
         print message
@@ -519,3 +497,30 @@ Available plugins:
 
 # For backwards compatibility
 publish_all = publish
+
+
+def _format_paths(paths):
+    """Return paths at one new each"""
+    message = ''
+    for path in paths:
+        message += "{0}- {1}\n".format(TAB, path)
+    return message[:-1]  # Discard last newline
+
+
+def _format_plugins(plugins):
+    message = ''
+    for plugin in sorted(plugins, key=lambda p: p.__name__):
+        line = "{tab}- {plug}".format(
+            tab=TAB, plug=plugin.__name__)
+
+        if hasattr(plugin, 'families'):
+            line = line.ljust(50) + " "
+            for family in plugin.families:
+                line += "%s, " % family
+            line = line[:-2]
+
+        line += "\n"
+
+        message += line
+
+    return message[:-1]

--- a/pyblish/main.py
+++ b/pyblish/main.py
@@ -290,7 +290,7 @@ class Publish(object):
         self._log_plugin(plugin)
 
         for instance, error in plugin().process(self.context):
-            if instance is None:
+            if instance is None and error is None:
                 self.log.debug("Skipped, no compatible instances.")
                 continue
 

--- a/pyblish/main.py
+++ b/pyblish/main.py
@@ -199,7 +199,8 @@ class Publish(object):
                     tab=TAB,
                     exception=error,
                     plugin=error.plugin.__name__))
-            print VALIDATIONS_FAILED_TEMPLATE.format(failures=failures)
+            print VALIDATIONS_FAILED_TEMPLATE.format(
+                failures="\n".join(failures))
 
         except Exception as exc:
             self.log.error("Unhandled exception: %s" % exc)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -175,7 +175,7 @@ class Plugin(object):
                         self.log.info("Skipping %s" % instance)
                         continue
 
-                    self.log.debug("Processing instance: %s" % instance)
+                    self.log.info("Processing instance: \"%s\"" % instance)
 
                     # Inject data
                     processed_by = instance.data('__processed_by__') or list()
@@ -360,7 +360,7 @@ class Extractor(Plugin):
 
         commit_dir = self.compute_commit_directory(instance=instance)
 
-        self.log.info("Moving {0} relative working file..".format(instance))
+        self.log.info("Moving \"%s\" relative working file.." % instance)
 
         if os.path.isdir(commit_dir):
             self.log.info("Existing directory found, merging..")
@@ -505,7 +505,7 @@ class Context(AbstractEntity):
 
 @pyblish.lib.log
 class Instance(AbstractEntity):
-    """An individually publishable component within scene
+    """An in-memory representation of one or more files
 
     Examples include rigs, models.
 
@@ -698,9 +698,7 @@ def environment_paths():
     env_var = config['paths_environment_variable']
     env_val = os.environ.get(env_var)
     if env_val:
-        sep = ';' if os.name == 'nt' else ':'
-        env_paths = env_val.split(sep)
-
+        env_paths = env_val.split(os.pathsep)
         for path in env_paths:
             plugin_path = _post_process_path(path)
             paths.append(plugin_path)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -974,6 +974,10 @@ def _isvalid(plugin):
         log.error("Plug-in must have an order")
         return False
 
+    if not isinstance(plugin.requires, basestring):
+        log.error("Plug-in requires must be of type string")
+        return False
+
     # Helper functions
     def has_families(_plugin):
         if not getattr(_plugin, 'families'):

--- a/pyblish/tests/test_main.py
+++ b/pyblish/tests/test_main.py
@@ -5,11 +5,12 @@ import pyblish.plugin
 from pyblish.vendor import mock
 from pyblish.vendor.nose.tools import with_setup
 from pyblish.tests.lib import (
-    setup, teardown, FAMILY, HOST, setup_failing, setup_full)
+    teardown, FAMILY, HOST, setup_failing, setup_full)
 
 
+@mock.patch('pyblish.main.Publish.log')
 @with_setup(setup_full, teardown)
-def test_publish_all():
+def test_publish_all(_):
     """publish() calls upon each convenience function"""
     ctx = pyblish.plugin.Context()
     pyblish.main.publish(context=ctx)
@@ -23,6 +24,7 @@ def test_publish_all():
 
 @mock.patch('pyblish.main.Publish.log')
 def test_publish_all_no_instances(mock_log):
+    """Having no instances is fine, a warning is logged"""
     ctx = pyblish.plugin.Context()
     pyblish.main.publish(ctx)
     assert mock_log.warning.called
@@ -30,6 +32,7 @@ def test_publish_all_no_instances(mock_log):
 
 @with_setup(setup_full, teardown)
 def test_publish_all_no_context():
+    """Not passing a context is fine"""
     ctx = pyblish.main.publish()
 
     for inst in ctx:
@@ -39,8 +42,9 @@ def test_publish_all_no_context():
         assert inst.data('conformed') is True
 
 
+@mock.patch('pyblish.main.Publish.log')
 @with_setup(setup_full, teardown)
-def test_validate_all():
+def test_validate_all(_):
     """validate_all() calls upon two of the convenience functions"""
     ctx = pyblish.plugin.Context()
     pyblish.main.validate_all(context=ctx)
@@ -52,8 +56,9 @@ def test_validate_all():
         assert inst.data('conformed') is False
 
 
+@mock.patch('pyblish.main.Publish.log')
 @with_setup(setup_full, teardown)
-def test_convenience():
+def test_convenience(_):
     """Convenience function work"""
     ctx = pyblish.plugin.Context()
 
@@ -90,8 +95,9 @@ def test_convenience():
         assert inst.data('conformed') is True
 
 
+@mock.patch('pyblish.main.Publish.log')
 @with_setup(setup_failing, teardown)
-def test_main_safe_processes_fail():
+def test_main_safe_processes_fail(_):
     """Failing selection, extraction or conform merely logs a message"""
     ctx = pyblish.plugin.Context()
     pyblish.main.select(ctx)

--- a/pyblish/vendor/iscompatible.py
+++ b/pyblish/vendor/iscompatible.py
@@ -1,0 +1,159 @@
+"""
+Python versioning with requirements.txt syntax
+==============================================
+
+iscompatible v\ |version|. gives you the power of the pip requirements.txt
+syntax for everyday python packages, modules, classes or arbitrary
+functions.
+
+The requirements.txt syntax allows you to specify inexact matches
+between a set of requirements and a version. For example, let's
+assume that the single package foo-5.6.1 exists on disk. The
+following requirements are all compatible with foo-5.6.1.
+
+===========   =================================================
+Requirement   Description
+===========   =================================================
+foo           any version of foo
+foo>=5        any version of foo, above or equal to 5
+foo>=5.6      any version of foo, above or equal to 5.6
+foo==5.6.1    exact match
+foo>5         foo-5 or greater, including minor and patch
+foo>5, <5.7   foo-5 or greater, but less than foo-5.7
+foo>0, <5.7   any foo version less than foo-5.7
+===========   =================================================
+
+Example:
+    >>> iscompatible("foo>=5", (5, 6, 1))
+    True
+    >>> iscompatible("foo>=5.6.1, <5.7", (5, 0, 0))
+    False
+    >>> MyPlugin = type("MyPlugin", (), {'version': (5, 6, 1)})
+    >>> iscompatible("foo==5.6.1", MyPlugin.version)
+    True
+
+References
+^^^^^^^^^^
+
+- `The requirements file-format`_
+
+.. _The requirements file-format: https://pip.readthedocs.org/en/1.1/requirements.html#the-requirements-file-format
+.. _VCS: https://pip.readthedocs.org/en/1.1/requirements.html#version-control
+.. _extras: http://peak.telecommunity.com/DevCenter/setuptools#declaring-extras-optional-features-with-their-own-dependencies
+
+"""
+
+version_info = (0, 1, 1)
+__version__ = "%s.%s.%s" % version_info
+
+
+import re
+import operator
+
+
+def iscompatible(requirements, version):
+    """Return whether or not `requirements` is compatible with `version`
+
+    Arguments:
+        requirements (str): Requirement to compare, e.g. foo==1.0.1
+        version (tuple): Version to compare against, e.g. (1, 0, 1)
+
+    Example:
+        >>> iscompatible("foo", (1, 0, 0))
+        True
+        >>> iscompatible("foo<=1", (0, 9, 0))
+        True
+        >>> iscompatible("foo>=1, <1.3", (1, 2, 0))
+        True
+        >>> iscompatible("foo>=0.9.9", (1, 0, 0))
+        True
+        >>> iscompatible("foo>=1.1, <2.1", (2, 0, 0))
+        True
+        >>> iscompatible("foo==1.0.0", (1, 0, 0))
+        True
+        >>> iscompatible("foo==1.0.0", (1, 0, 1))
+        False
+
+    """
+
+    results = list()
+
+    for operator_string, requirement_string in parse_requirements(requirements):
+        operator = operators[operator_string]
+        required = string_to_tuple(requirement_string)
+        result = operator(version, required)
+
+        results.append(result)
+
+    return all(results)
+
+
+def parse_requirements(line):
+    """Return list of tuples with (operator, version) from `line`
+
+    .. note:: This is a minimal re-implementation of
+        pkg_utils.parse_requirements and doesn't include support
+        for `VCS`_ or `extras`_.
+
+
+    Example:
+        >>> parse_requirements("foo==1.0.0")
+        [('==', '1.0.0')]
+        >>> parse_requirements("foo>=1.1.0")
+        [('>=', '1.1.0')]
+        >>> parse_requirements("foo>=1.1.0, <1.2")
+        [('>=', '1.1.0'), ('<', '1.2')]
+
+
+    """
+
+    LINE_END = re.compile(r"\s*(#.*)?$")
+    DISTRO = re.compile(r"\s*((\w|[-.])+)")
+    VERSION = re.compile(r"\s*(<=?|>=?|==|!=)\s*((\w|[-.])+)")
+    COMMA = re.compile(r"\s*,")
+
+    match = DISTRO.match(line)
+    p = match.end()
+    specs = list()
+
+    while not LINE_END.match(line, p):
+        match = VERSION.match(line, p)
+        if not match:
+            raise ValueError(
+                "Expected version spec in",
+                line, "at", line[p:])
+
+        specs.append(match.group(*(1, 2)))
+        p = match.end()
+
+        match = COMMA.match(line, p)
+        if match:
+            p = match.end()  # Skip comma
+        elif not LINE_END.match(line, p):
+            raise ValueError(
+                "Expected ',' or end-of-list in",
+                line, "at", line[p:])
+
+    return specs
+
+
+def string_to_tuple(version):
+    """Convert version as string to tuple
+
+    Example:
+        >>> string_to_tuple("1.0.0")
+        (1, 0, 0)
+        >>> string_to_tuple("2.5")
+        (2, 5)
+
+    """
+
+    return tuple(map(int, version.split(".")))
+
+
+operators = {"<":   operator.lt,
+             "<=":  operator.le,
+             "==":  operator.eq,
+             "!=":  operator.ne,
+             ">=":  operator.ge,
+             ">":   operator.gt}

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 0
-VERSION_PATCH = 8
+VERSION_PATCH = 9
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/run_testsuite.py
+++ b/run_testsuite.py
@@ -9,5 +9,5 @@ from pyblish.vendor import nose
 
 if __name__ == '__main__':
     argv = sys.argv[:]
-    argv.extend(['--verbose', '--exclude=vendor', '--with-doctest'])
+    argv.extend(['--exclude=vendor', '--with-doctest'])
     nose.main(argv=argv)


### PR DESCRIPTION
Hi all,

Small update for the future - Requires.
### Requires

`requires` is an attribute of a plug-in specifying with which version of the Pyblish API the plug-in is compatible with. This is so that if you have plug-ins that pre-date a particular version since a breaking change - such as v2.0 - the discover mechanism will recognise this and log a message about what has happened.

This way, we can keep a mixture of plug-ins available, without any of them causing any trouble. The idea is for you to be able to update Pyblish, whilst later on update your plug-ins, should you want to.

It looks like this.

``` python
class ValidatePullRequest(Validator):
    requires = "pyblish>=1.0.8"
```

This plug-in requires a version of Pyblish _above or equal_ to 1.0.8. Essentially saying, if you plug-in is discovered by 1.0.9, it won't get loaded.

The syntax is coming from the standard PyPI requirements.txt, and the library responsible for making comparisons, along with its documentation, can be found here.
- https://github.com/mottosso/iscompatible
- http://iscompatible.readthedocs.org/en/latest/
### Later on

The idea is then to allow for multiple criterias.

``` python
class ValidatePullRequest(Validator):
    requires = ["pyblish>=1.0.8", "pyblish-maya>=0.9, <=1.1.2"]
```

This one requires both Pyblish up to 1.0.8 and Pyblish for Maya, versioned between 0.9 and 1.1.2. This is so that we can design plug-ins with intricate requirements that say "No, I need extension X in order to work", allowing users to re-use as much as possible of other extensions, whilst still keeping their hair.
- See [CHANGES](https://github.com/mottosso/pyblish/blob/d2050b7c2e3e67037c72ec1f872b11bf76c45992/CHANGES) for more.

Best,
Marcus
