### PR TITLE
Maintenance update

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,11 @@ pyblish Changelog
 
 This contains all major version changes between pyblish releases.
 
+Version 1.0.15
+--------------
+
+- API: Plugin.repair_* documented and implemented by default
+
 Version 1.0.14
 --------------
 

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Version 1.0.15
 --------------
 
 - API: Plugin.repair_* documented and implemented by default
+- API: Added lib.where()
+- API: Added `.id` attribute to instances and plug-ins
 
 Version 1.0.14
 --------------

--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -207,3 +207,35 @@ def import_module(name, package=None):
     __import__(name)
 
     return sys.modules[name]
+
+
+def where(program):
+    r"""Parse PATH for executables
+
+    Windows note:
+        PATHEXT yields possible suffixes, such as .exe, .bat and .cmd
+
+    Usage:
+        >> where("python")
+        'c:\\python27\\python.exe'
+
+    """
+
+    suffixes = [""]
+
+    try:
+        # Append Windows suffixes, such as .exe, .bat and .cmd
+        suffixes.extend(os.environ.get("PATHEXT").split(os.pathsep))
+    except:
+        pass
+
+    for path in os.environ["PATH"].split(os.pathsep):
+
+        # A path may be empty.
+        if not path:
+            continue
+
+        for suffix in suffixes:
+            full_path = os.path.join(path, program + suffix)
+            if os.path.isfile(full_path):
+                return full_path

--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -8,6 +8,14 @@ _windows_device_files = ('CON', 'AUX', 'COM1', 'COM2', 'COM3', 'COM4',
                          'LPT1', 'LPT2', 'LPT3', 'PRN', 'NUL')
 
 
+class classproperty(object):
+    def __init__(self, getter):
+        self.getter = getter
+
+    def __get__(self, instance, owner):
+        return self.getter(owner)
+
+
 def log(cls):
     """Decorator for attaching a logger to the class `cls`
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -152,6 +152,10 @@ class Plugin(object):
     def __repr__(self):
         return u"%s.%s(%r)" % (__name__, type(self).__name__, self.__str__())
 
+    @pyblish.lib.classproperty
+    def id(cls):
+        return cls.__name__
+
     def process(self, context, instances=None):
         """Perform processing upon context `context`
 
@@ -593,6 +597,10 @@ class Instance(AbstractEntity):
         return u"%s.%s(\"%s\")" % (__name__, type(self).__name__, self)
 
     def __str__(self):
+        return self.name
+
+    @property
+    def id(self):
         return self.name
 
     def __init__(self, name, parent=None):

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -273,6 +273,34 @@ class Plugin(object):
 
         """
 
+    def repair_instance(self, instance):
+        """Repair given `instance`
+
+        Implement this method in your subclasses in order for
+        the given instance to be repaired.
+
+        Returns:
+            None
+
+        Raises:
+            Any error
+
+        """
+
+    def repair_context(self, context):
+        """Repair given `context`
+
+        Implement this method in your subclasses in order for
+        the context to be repaired.
+
+        Returns:
+            None
+
+        Raises:
+            Any error
+
+        """
+
     def process_all(self, context):
         """Convenience method of the above :meth:`process`
 

--- a/pyblish/tests/plugins/full/validate_instances.py
+++ b/pyblish/tests/plugins/full/validate_instances.py
@@ -3,7 +3,7 @@ import pyblish.api
 
 
 @pyblish.api.log
-class ValidateInstance(pyblish.api.Validator):
+class ValidateInstances(pyblish.api.Validator):
     hosts = ['python']
     families = ['full']
     version = (0, 1, 0)

--- a/pyblish/tests/test_lib.py
+++ b/pyblish/tests/test_lib.py
@@ -1,0 +1,10 @@
+import sys
+import pyblish.lib
+
+from pyblish.vendor.nose.tools import *
+
+
+def test_where():
+    """lib.where works fine"""
+    exe = pyblish.lib.where("python")
+    assert_equals(sys.executable.lower(), exe.lower())

--- a/pyblish/tests/test_util.py
+++ b/pyblish/tests/test_util.py
@@ -12,8 +12,14 @@ from pyblish.tests.lib import (
 @with_setup(setup_full, teardown)
 def test_publish_all(_):
     """publish() calls upon each convenience function"""
-    ctx = pyblish.plugin.Context()
-    pyblish.util.publish(context=ctx)
+    plugins = pyblish.plugin.discover()
+
+    assert "ConformInstances" in [p.__name__ for p in plugins]
+    assert "SelectInstances" in [p.__name__ for p in plugins]
+    assert "ValidateInstances" in [p.__name__ for p in plugins]
+    assert "ExtractInstances" in [p.__name__ for p in plugins]
+
+    ctx = pyblish.util.publish()
 
     for inst in ctx:
         assert inst.data('selected') is True

--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -49,7 +49,8 @@ __all__ = ['select',
            'extract',
            'conform',
            'publish',
-           'publish_all']
+           'publish_all',
+           'validate_all']
 
 
 def publish(context=None,

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 0
-VERSION_PATCH = 14
+VERSION_PATCH = 15
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
Primarily and addition of the `.id` attribute on instances and plug-ins to uniquely identify them. Currently defaults to their name so as to not break backwards compatibility, but opens up doors for more unique identifiers should the need occur.
## Version 1.0.15
- API: Plugin.repair_\* documented and implemented by default
- API: Added lib.where()
- API: Added `.id` attribute to instances and plug-ins
