### PR TITLE
Fix time() returning local time but claiming to return UTC.

### DIFF
--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -65,7 +65,8 @@ def extract_traceback(exception):
 
 
 def time():
-    return datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    """Return ISO formatted string representation of current UTC time."""
+    return '%sZ' % datetime.datetime.utcnow().isoformat()
 
 
 class ItemList(list):


### PR DESCRIPTION
The time function was returning a string containing the local time with the UTC timezone designation 'Z' incorrectly appended. I've changed this to return the current UTC time. Since the manual strftime call was producing the same output as the builtin isoformat function I also opted to use the builtin function.
