### PR TITLE
Simplify Iterator

### DIFF
--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -182,11 +182,6 @@ def instances_by_plugin(instances, plugin):
 
     compatible = list()
 
-    if not plugin.__instanceEnabled__:
-        # A plug-in not capable of handling instances should
-        # not be given the opportunity to handle them.
-        return compatible
-
     for instance in instances:
         family = instance.data["family"]
 
@@ -240,12 +235,11 @@ def Iterator(plugins, context):
     for plugin in plugins:
         instances = instances_by_plugin(context, plugin)
 
-        # Run once for every instance..
-        for instance in instances:
-            yield plugin, instance
+        if plugin.__instanceEnabled__:
+            for instance in instances:
+                yield plugin, instance
 
-        # Plus once for the context
-        if not plugin.__instanceEnabled__:
+        else:
             yield plugin, None
 
 

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -240,12 +240,13 @@ def Iterator(plugins, context):
     for plugin in plugins:
         instances = instances_by_plugin(context, plugin)
 
-        # Run once for every instance, plus once for context
-        for instance in instances + [None]:
-            if instance is None and plugin.__instanceEnabled__:
-                continue
-
+        # Run once for every instance..
+        for instance in instances:
             yield plugin, instance
+
+        # Plus once for the context
+        if not plugin.__instanceEnabled__:
+            yield plugin, None
 
 
 @lib.deprecated

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -176,7 +176,7 @@ class MetaPlugin(type):
         append_logger(cls)
         evaluate_pre11(cls)
         evaluate_enabledness(cls)
-        cls.id = property(lambda self: str(uuid.uuid4()))
+        cls.id = lib.classproperty(lambda self: str(uuid.uuid4()))
         return super(MetaPlugin, cls).__init__(*args, **kwargs)
 
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -19,6 +19,7 @@ import logging
 import inspect
 import warnings
 import contextlib
+import uuid
 
 # Local library
 from . import (
@@ -652,7 +653,7 @@ class Context(AbstractEntity):
         Example:
             >>> context = Context()
             >>> instance = context.create_instance("MyInstance")
-            >>> "MyInstance" in context
+            >>> instance.id in context
             True
             >>> instance in context
             True
@@ -690,9 +691,9 @@ class Context(AbstractEntity):
         Example:
             >>> context = Context()
             >>> instance = context.create_instance("MyInstance")
-            >>> assert context["MyInstance"].name == "MyInstance"
+            >>> assert context[instance.id].name == "MyInstance"
             >>> assert context[0].name == "MyInstance"
-            >>> assert context.get("MyInstance").name == "MyInstance"
+            >>> assert context.get(instance.id).name == "MyInstance"
 
         """
 
@@ -730,8 +731,6 @@ class Instance(AbstractEntity):
 
     """
 
-    id = property(lambda self: self.name)
-
     def __eq__(self, other):
         return self.id == getattr(other, "id", None)
 
@@ -750,6 +749,9 @@ class Instance(AbstractEntity):
         assert parent is None or isinstance(parent, AbstractEntity)
         self.name = name
         self.parent = parent
+        
+        # Generate unique id for this instance
+        self.id = uuid.uuid4()
 
         self.data["name"] = name
         self.data["family"] = "default"

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -490,6 +490,9 @@ def __explicit_process(plugin, context, instance=None, action=None):
             runner(*args)
             result["success"] = True
     except Exception as error:
+        # FIXME: This is apparently not very healthy,
+        # as it creates a circular reference.
+        # http://stackoverflow.com/a/11417308/478949
         lib.emit("pluginFailed", plugin=plugin, context=context,
                  instance=instance, error=error)
         lib.extract_traceback(error)
@@ -642,19 +645,51 @@ class _Dict(dict):
 
 
 class AbstractEntity(list):
-    """Superclass for Context and Instance"""
+    """Superclass for Context and Instance
 
-    def __init__(self):
-        self.data = _Dict(self)
+    Attributes:
+        id (str): Unique identifier of instance
+        name (str): Name of instance
+        data (dict): Data shared between plug-ins
+        parent (AbstractEntity): Optional parent of instance
+
+    """
+
+    def __init__(self, name, parent=None):
+        assert isinstance(name, basestring)
+        assert parent is None or isinstance(parent, AbstractEntity)
+
+        # Read-only properties
+        self._name = name
+        self._data = _Dict(self)
         self._id = str(uuid.uuid4())
+        self._parent = parent
+
+        if parent is not None:
+            parent.append(self)
 
     @property
     def id(self):
         return self._id
 
+    @property
+    def parent(self):
+        return self._parent
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def data(self):
+        return self._data
+
 
 class Context(AbstractEntity):
     """Maintain a collection of Instances"""
+
+    def __init__(self, name="Context", parent=None):
+        super(Context, self).__init__(name, parent)
 
     def __contains__(self, key):
         """Support both Instance objects and `id` strings
@@ -702,7 +737,6 @@ class Context(AbstractEntity):
             >>> instance = context.create_instance("MyInstance")
             >>> assert context[instance.id].name == "MyInstance"
             >>> assert context[0].name == "MyInstance"
-            >>> assert context.get(instance.id).name == "MyInstance"
 
         """
 
@@ -714,10 +748,16 @@ class Context(AbstractEntity):
             raise KeyError("%s not in list" % item)
 
     def get(self, key, default=None):
-        try:
-            return next(c for c in self if c.id == key)
-        except StopIteration:
-            return default
+        """Enable support for dict-like getting of children by id
+
+        Example
+            >>> context = Context()
+            >>> instance = context.create_instance("MyInstance")
+            >>> assert context.get(instance.id).name == "MyInstance"
+
+        """
+
+        return next((c for c in self if c.id == key), default)
 
 
 @lib.log
@@ -733,12 +773,12 @@ class Instance(AbstractEntity):
             supplied automatically when creating instances with
             :class:`Context.create_instance()`.
 
-    Attributes:
-        id (str): Unique identifier of instance
-        name (str): Name of instance
-        parent (AbstractEntity): Optional parent of instance
-
     """
+    
+    def __init__(self, name, parent=None):
+        super(Instance, self).__init__(name, parent)
+        self._data["family"] = "default"
+        self._data["name"] = name
 
     def __eq__(self, other):
         return self._id == getattr(other, "id", None)
@@ -752,39 +792,19 @@ class Instance(AbstractEntity):
     def __str__(self):
         return self._name
 
-    def __init__(self, name, parent=None):
-        super(Instance, self).__init__()
-        assert isinstance(name, basestring)
-        assert parent is None or isinstance(parent, AbstractEntity)
-
-        # Read-only properties
-        self._name = name
-        self._parent = parent
-
-        self.data["name"] = name
-        self.data["family"] = "default"
-
-        if parent is not None:
-            parent.append(self)
-
-    @property
-    def parent(self):
-        return self._parent
-
-    @property
-    def name(self):
-        return self._name
-
     @property
     def context(self):
         """Return top-level parent; the context"""
         parent = self.parent
-        while parent:
+        while parent.parent:
             try:
                 parent = parent.parent
             except:
                 break
-        assert isinstance(parent, Context)
+
+        assert isinstance(parent, Context), ("Parent was not a Context:"
+                                             "%s" % type(parent))
+
         return parent
 
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1220,11 +1220,11 @@ def discover(type=None, regex=None, paths=None):
                 continue
 
             for plugin in plugins_from_module(module):
-                if plugin.id in plugins:
+                if plugin.__name__ in plugins:
                     log.debug("Duplicate plug-in found: %s", plugin)
                     continue
 
-                plugins[plugin.id] = plugin
+                plugins[plugin.__name__] = plugin
 
     # Include plug-ins from registration.
     # Directly registered plug-ins take precedence.

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -176,6 +176,7 @@ class MetaPlugin(type):
         append_logger(cls)
         evaluate_pre11(cls)
         evaluate_enabledness(cls)
+        cls.id = property(lambda self: str(uuid.uuid4()))
         return super(MetaPlugin, cls).__init__(*args, **kwargs)
 
 
@@ -219,8 +220,7 @@ class Plugin(object):
     optional = False
     requires = "pyblish>=1"
     actions = []
-
-    id = lib.classproperty(lambda cls: cls.__name__)
+    id = None  # Defined by metaclass
 
     def __str__(self):
         return self.label or type(self).__name__
@@ -330,7 +330,9 @@ class MetaAction(type):
     """Inject additional metadata into Action"""
 
     def __init__(cls, *args, **kwargs):
+        cls.id = property(lambda self: str(uuid.uuid4()))
         cls.__error__ = None
+
         if cls.on not in ("all",
                           "processed",
                           "failed",
@@ -374,8 +376,6 @@ class Action(object):
     active = True
     on = "all"
     icon = None
-
-    id = lib.classproperty(lambda cls: cls.__name__)
 
     def __str__(self):
         return self.label or type(self).__name__
@@ -641,8 +641,6 @@ class AbstractEntity(list):
     def __init__(self):
         self.data = _Dict(self)
         self._id = str(uuid.uuid4())
-
-        self.data["id"] = self._id
 
     @property
     def id(self):

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -640,12 +640,17 @@ class AbstractEntity(list):
 
     def __init__(self):
         self.data = _Dict(self)
+        self._id = str(uuid.uuid4())
+
+        self.data["id"] = self._id
+
+    @property
+    def id(self):
+        return self._id
 
 
 class Context(AbstractEntity):
     """Maintain a collection of Instances"""
-
-    id = property(lambda self: "Context")
 
     def __contains__(self, key):
         """Support both Instance objects and `id` strings
@@ -732,32 +737,39 @@ class Instance(AbstractEntity):
     """
 
     def __eq__(self, other):
-        return self.id == getattr(other, "id", None)
+        return self._id == getattr(other, "id", None)
 
     def __ne__(self, other):
-        return self.id != getattr(other, "id", None)
+        return self._id != getattr(other, "id", None)
 
     def __repr__(self):
         return u"%s.%s(\"%s\")" % (__name__, type(self).__name__, self)
 
     def __str__(self):
-        return self.name
+        return self._name
 
     def __init__(self, name, parent=None):
         super(Instance, self).__init__()
         assert isinstance(name, basestring)
         assert parent is None or isinstance(parent, AbstractEntity)
-        self.name = name
-        self.parent = parent
-        
-        # Generate unique id for this instance
-        self.id = str(uuid.uuid4())
+    
+        # Read-only properties
+        self._name = name
+        self._parent = parent
 
         self.data["name"] = name
         self.data["family"] = "default"
 
         if parent is not None:
             parent.append(self)
+
+    @property
+    def parent(self):
+        return self._parent
+        
+    @property
+    def name(self):
+        return self._name
 
     @property
     def context(self):

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -176,7 +176,11 @@ class MetaPlugin(type):
         append_logger(cls)
         evaluate_pre11(cls)
         evaluate_enabledness(cls)
-        cls.id = lib.classproperty(lambda self: str(uuid.uuid4()))
+
+        # Compute once
+        cls._id = str(uuid.uuid4())
+        cls.id = lib.classproperty(lambda self: self._id)
+
         return super(MetaPlugin, cls).__init__(*args, **kwargs)
 
 
@@ -330,7 +334,9 @@ class MetaAction(type):
     """Inject additional metadata into Action"""
 
     def __init__(cls, *args, **kwargs):
-        cls.id = property(lambda self: str(uuid.uuid4()))
+        cls._id = str(uuid.uuid4())
+        cls.id = lib.classproperty(lambda self: cls._id)
+
         cls.__error__ = None
 
         if cls.on not in ("all",
@@ -750,7 +756,7 @@ class Instance(AbstractEntity):
         super(Instance, self).__init__()
         assert isinstance(name, basestring)
         assert parent is None or isinstance(parent, AbstractEntity)
-    
+
         # Read-only properties
         self._name = name
         self._parent = parent
@@ -764,7 +770,7 @@ class Instance(AbstractEntity):
     @property
     def parent(self):
         return self._parent
-        
+
     @property
     def name(self):
         return self._name

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -751,7 +751,7 @@ class Instance(AbstractEntity):
         self.parent = parent
         
         # Generate unique id for this instance
-        self.id = uuid.uuid4()
+        self.id = str(uuid.uuid4())
 
         self.data["name"] = name
         self.data["family"] = "default"

--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -61,13 +61,8 @@ def publish(context=None, plugins=None, **kwargs):
     for Plugin, instance in logic.Iterator(collectors, context):
         plugin.process(Plugin, context, instance)
 
-<<<<<<< HEAD
     # Exclude collectors from further processing
     plugins = list(p for p in plugins if p not in collectors)
-=======
-        # Exclude collectors for second pass
-        plugins.remove(Plugin) if Plugin in plugins else None
->>>>>>> aecae8fb45a0d517c5ab77d99701c42aa157365f
 
     # Exclude plug-ins that do not have at
     # least one compatible instance.

--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -58,18 +58,18 @@ def publish(context=None, plugins=None, **kwargs):
     )
 
     # First pass, collection
-    for plug, instance in logic.Iterator(collectors, context):
-        plugin.process(plug, context, instance)
+    for Plugin, instance in logic.Iterator(collectors, context):
+        plugin.process(Plugin, context, instance)
 
         # Exclude collectors for second pass
-        plugins.remove(plug)
+        plugins.remove(Plugin) if Plugin in plugins else None
 
     # Exclude plug-ins that do not have at
     # least one compatible instance.
-    for plug in list(plugins):
-        if plug.__instanceEnabled__:
-            if not logic.instances_by_plugin(context, plug):
-                plugins.remove(plug)
+    for Plugin in list(plugins):
+        if Plugin.__instanceEnabled__:
+            if not logic.instances_by_plugin(context, Plugin):
+                plugins.remove(Plugin)
 
     # Keep track of state, so we can cancel on failed validation
     state = {
@@ -80,15 +80,15 @@ def publish(context=None, plugins=None, **kwargs):
     test = api.registered_test()
 
     # Second pass, the remainder
-    for plug, instance in logic.Iterator(plugins, context):
-        state["nextOrder"] = plug.order
+    for Plugin, instance in logic.Iterator(plugins, context):
+        state["nextOrder"] = Plugin.order
 
         if test(**state):
             log.error("Stopped due to: %s" % test(**state))
             break
 
         try:
-            result = plugin.process(plug, context, instance)
+            result = plugin.process(Plugin, context, instance)
 
         except:
             # This exception is unexpected
@@ -99,7 +99,7 @@ def publish(context=None, plugins=None, **kwargs):
             # Make note of the order at which the
             # potential error error occured.
             if result["error"]:
-                state["ordersWithError"].add(plug.order)
+                state["ordersWithError"].add(Plugin.order)
 
         if isinstance(result, Exception):
             log.error("An unexpected error happened: %s" % result)

--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -61,8 +61,8 @@ def publish(context=None, plugins=None, **kwargs):
     for plug, instance in logic.Iterator(collectors, context):
         plugin.process(plug, context, instance)
 
-        # Exclude collectors for second pass
-        plugins.remove(plug)
+    # Exclude collectors from further processing
+    plugins = list(p for p in plugins if p not in collectors)
 
     # Exclude plug-ins that do not have at
     # least one compatible instance.

--- a/tests/pre13/test_plugin.py
+++ b/tests/pre13/test_plugin.py
@@ -66,7 +66,7 @@ class BadFamilies2(pyblish.api.Plugin):
 
     plugins = pyblish.plugin.plugins_from_module(module)
 
-    assert [p.id for p in plugins] == ["MyPlugin"], plugins
+    assert [p.__name__ for p in plugins] == ["MyPlugin"], plugins
 
 
 @with_setup(lib.setup_empty, lib.teardown)
@@ -97,7 +97,7 @@ class MyPlugin(pyblish.api.Plugin):
 
     exec code in module.__dict__
     MyPlugin = pyblish.plugin.plugins_from_module(module)[0]
-    assert MyPlugin.id == "MyPlugin"
+    assert MyPlugin.__name__ == "MyPlugin"
 
     assert_true(MyPlugin().process(True))
     assert_true(MyPlugin().module_is_present())

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -28,7 +28,7 @@ def test_data():
 
     # Not passing a key returns all data as a dict,
     # but there is none yet.
-    assert ctx.data(key=None) == dict()
+    assert ctx.data(key=None) == dict(), ctx.data(key=None)
 
     key = 'test_key'
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -56,19 +56,19 @@ def test_instance_equality():
     inst3 = pyblish.plugin.Instance('Test2')
 
     assert inst1 != inst2
-    assert inst2 == inst3
+    assert inst2 != inst3
 
 
 def test_context_itemgetter():
     """Context.get() works"""
     context = pyblish.api.Context()
-    context.create_instance("MyInstanceA")
-    context.create_instance("MyInstanceB")
+    instanceA = context.create_instance("MyInstanceA")
+    instanceB = context.create_instance("MyInstanceB")
 
-    assert context["MyInstanceA"].name == "MyInstanceA"
-    assert context["MyInstanceB"].name == "MyInstanceB"
-    assert context.get("MyInstanceA").name == "MyInstanceA"
-    assert context.get("MyInstanceB").name == "MyInstanceB"
+    assert context[instanceA.id].name == "MyInstanceA"
+    assert context[instanceB.id].name == "MyInstanceB"
+    assert context.get(instanceA.id).name == "MyInstanceA"
+    assert context.get(instanceB.id).name == "MyInstanceB"
     assert context[0].name == "MyInstanceA"
     assert context[1].name == "MyInstanceB"
 
@@ -77,8 +77,8 @@ def test_in():
     """Querying whether an Instance is in a Context works"""
 
     context = pyblish.api.Context()
-    context.create_instance("MyInstance")
-    assert "MyInstance" in context
+    instance = context.create_instance("MyInstance")
+    assert instance.id in context
     assert "NotExist" not in context
 
 
@@ -115,6 +115,15 @@ def test_context_getitem_validrange():
     context = pyblish.api.Context()
     context.create_instance("MyInstance")
     assert context[0].data["name"] == "MyInstance"
+
+
+def test_context_instance_unique_id():
+    """Same named instances have unique ids"""
+
+    context = pyblish.api.Context()
+    instance1 = context.create_instance("MyInstance")
+    instance2 = context.create_instance("MyInstance")
+    assert instance1.id != instance2.id
 
 
 if __name__ == '__main__':

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -14,6 +14,7 @@ from nose.tools import (
 from . import lib
 
 
+@with_setup(lib.setup_empty, lib.teardown)
 def test_unique_id():
     """Plug-ins and instances have an id"""
 
@@ -35,6 +36,16 @@ def test_unique_id():
 
     context = pyblish.plugin.Context()
     assert_equals(context.id, context.id)
+
+    # Even across discover()'s
+    # Due to the fact that an ID is generated on module
+    # load, which only happens once per process unless
+    # module is forcefully reloaded by the user.
+    pyblish.api.register_plugin(MyPlugin)
+    plugins = list(p for p in pyblish.api.discover()
+                   if p.id == MyPlugin.id)
+    assert len(plugins) == 1, plugins
+    assert plugins[0].__name__ == MyPlugin.__name__
 
 
 def test_context_from_instance():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,10 +20,21 @@ def test_unique_id():
     class MyPlugin(pyblish.plugin.Collector):
         pass
 
+    class MyAction(pyblish.plugin.Action):
+        pass
+
     assert_true(hasattr(MyPlugin, "id"))
 
     instance = pyblish.plugin.Instance("MyInstance")
     assert_true(hasattr(instance, "id"))
+
+    # IDs are persistent
+    assert_equals(instance.id, instance.id)
+    assert_equals(MyAction.id, MyAction.id)
+    assert_equals(MyPlugin.id, MyPlugin.id)
+
+    context = pyblish.plugin.Context()
+    assert_equals(context.id, context.id)
 
 
 def test_context_from_instance():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -312,7 +312,7 @@ def test_action():
     pyblish.plugin.process(
         plugin=MyPlugin,
         context=context,
-        action="MyAction")
+        action=MyAction.id)
 
     assert count["#"] == 1
 
@@ -572,7 +572,7 @@ def test_explicit_action():
     pyblish.plugin.process(
         plugin=MyPlugin,
         context=context,
-        action="MyAction")
+        action=MyAction.id)
 
 
 def test_explicit_results():
@@ -651,7 +651,7 @@ def test_actions_and_explicit_plugins():
     result = pyblish.plugin.process(MyValidator,
                                     context,
                                     instance=None,
-                                    action="MyAction")
+                                    action=MyAction.id)
     assert count["#"] == 1
     assert str(result["error"]) == "Errored", result
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -15,7 +15,7 @@ from . import lib
 
 
 def test_unique_id():
-    """Plug-ins and instances have a unique id"""
+    """Plug-ins and instances have an id"""
 
     class MyPlugin(pyblish.plugin.Collector):
         pass

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,35 @@
+from . import lib
+
+import pyblish.lib
+import pyblish.compat
+from nose.tools import (
+    with_setup
+)
+
+
+@with_setup(lib.setup, lib.teardown)
+def test_multiple_instance_publish_util():
+    """Multiple instances work with util.publish()
+
+    This also ensures it operates correctly with an
+    InstancePlugin collector.
+
+    """
+
+    class MyContextCollector(pyblish.api.ContextPlugin):
+    	order = pyblish.api.CollectorOrder
+        def process(self, context):
+            context.create_instance("A")
+            context.create_instance("B")
+
+    class MyInstancePluginCollector(pyblish.api.InstancePlugin):
+    	order = pyblish.api.CollectorOrder + 0.1
+        def process(self, instance):
+            pass
+
+    pyblish.api.register_plugin(MyContextCollector)
+    pyblish.api.register_plugin(MyInstancePluginCollector)
+
+    # Ensure it runs without errors
+    context = pyblish.util.publish()
+

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,7 @@ from nose.tools import (
 
 
 @with_setup(lib.setup, lib.teardown)
-def test_multiple_instance_publish_util():
+def test_multiple_instance_util_publish():
     """Multiple instances work with util.publish()
 
     This also ensures it operates correctly with an
@@ -16,16 +16,21 @@ def test_multiple_instance_publish_util():
 
     """
 
+    count = {"#": 0}
+
     class MyContextCollector(pyblish.api.ContextPlugin):
     	order = pyblish.api.CollectorOrder
         def process(self, context):
             context.create_instance("A")
             context.create_instance("B")
+            count["#"] += 1
+
 
     class MyInstancePluginCollector(pyblish.api.InstancePlugin):
     	order = pyblish.api.CollectorOrder + 0.1
         def process(self, instance):
-            pass
+        	count["#"] += 1
+
 
     pyblish.api.register_plugin(MyContextCollector)
     pyblish.api.register_plugin(MyInstancePluginCollector)
@@ -33,3 +38,4 @@ def test_multiple_instance_publish_util():
     # Ensure it runs without errors
     context = pyblish.util.publish()
 
+    assert count["#"] == 3


### PR DESCRIPTION
To help with #250, the Iterator has seen some simplification that should help in understanding how it works.

**Before**

``` python
def Iterator(plugins, context):
    for plugin in plugins:
        instances = instances_by_plugin(context, plugin)

        # Run once for every instance, plus once for context
        for instance in instances + [None]:
            if instance is None and plugin.__instanceEnabled__:
                continue

            yield plugin, instance
```

**After**

``` python
def Iterator(plugins, context):
    for plugin in plugins:
        instances = instances_by_plugin(context, plugin)

        if plugin.__instanceEnabled__:
            for instance in instances:
                yield plugin, instance

        else:
            yield plugin, None
```
