### PR TITLE
Python 3 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ docs/_*
 build
 playground.py
 *.sublime-*
-__*
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/_*
 build
 playground.py
 *.sublime-*
+__*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
 - 2.6
 - 2.7
+- 3.5
 install:
 - pip install coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ deploy:
   user: mottosso
   distributions: "sdist"
   password:
-    secure: WHvKto4HrDGY/3gokOxqTW8wVlP8C0CuQKIPW6DAhcJB5L8oJ6LLpm/1FRhn9trkhTcQNjXSrMwZqXCK9e5vuvY5rdsc49K81mOsGhRTgN5k9LFqrJ/AEExagjRfQrMDfvS5lsaCShPBlUIDABwNUI/wEsCRzyHryfXnIKHsPsY=
+    secure: fwXIOGKn38gJFNkzlpvholQBhSBzNorOnMvs04JT3+Fdq6ys2TiUV6tlXHDwo6DkMY++USI19oD9NWlvg8gQaRJq4g2V/taazn8XDv1XnyKLzb6DnAT1ALilJtbIgotH/0QNOvkDP40a8UDwbelE0aR4AptNO1Ts7n1eERygENA=
   on:
     tags: true
     all_branches: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,8 +42,8 @@ environment:
 
 install:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
-  - pip install nose
-  - pip install coverage
+  - python -m pip install nose
+  - python -m pip install coverage
 
-test_script:
+build_script:
   - python run_coverage.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-  matrix:
+matrix:
     - PYTHON: "C:\\Python26"
       PYTHON_VERSION: "2.6.6"
       PYTHON_ARCH: "32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,36 @@
+  matrix:
+    - PYTHON: "C:\\Python26"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+    
+    - PYTHON: "C:\\Python26-x64"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "64"
+    
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.8"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.5"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.5"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.1"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.1"
+      PYTHON_ARCH: "64"
+
 install:
   - set PATH=C:\Python27-x64;%PATH%
   - set PATH=C:\Python27-x64\scripts;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,11 +31,18 @@
       PYTHON_VERSION: "3.4.1"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.1"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.1"
+      PYTHON_ARCH: "64"
+
 install:
-  - set PATH=C:\Python27-x64;%PATH%
-  - set PATH=C:\Python27-x64\scripts;%PATH%
+  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - pip install nose
   - pip install coverage
 
-build_script:
-  - python run_coverage.py
+test_script:
+  - %CMD_IN_ENV% python run_coverage.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,8 +42,8 @@ environment:
 
 install:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
-  - python -m pip install nose
-  - python -m pip install coverage
+  - pip install nose
+  - pip install coverage
 
 build_script:
   - python run_coverage.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
-matrix:
+environment:
+  matrix:
     - PYTHON: "C:\\Python26"
       PYTHON_VERSION: "2.6.6"
       PYTHON_ARCH: "32"
@@ -45,4 +46,4 @@ install:
   - pip install coverage
 
 test_script:
-  - %CMD_IN_ENV% python run_coverage.py
+  - python run_coverage.py

--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -84,7 +84,6 @@ from .plugin import (
 from .lib import (
     log,
     time as __time,
-    format_filename,
     emit,
     main_package_path as __main_package_path
 )
@@ -114,6 +113,7 @@ from .compat import (
     sort,
     Selector,
     Conformer,
+    format_filename,
 )
 
 

--- a/pyblish/compat.py
+++ b/pyblish/compat.py
@@ -129,99 +129,14 @@ def add(self, other):
 plugin.Context.create_asset = create_asset
 plugin.Context.add = add
 
-if six.PY3:
-    @lib.deprecated
-    def format_filename(filename):
-        pass
+@lib.deprecated
+def format_filename(filename):
+    return filename
 
 
-    @lib.deprecated
-    def format_filename2(filename):
-        pass
-
-else:
-    def format_filename(filename):
-        """Convert arbitrary string to valid filename, django-style.
-    
-        Modified from django.utils.text.get_valid_filename()
-    
-        Returns the given string converted to a string that can be used for a clean
-        filename. Specifically, leading and trailing spaces are removed; other
-        spaces are converted to underscores; and anything that is not a unicode
-        alphanumeric, dash, underscore, or dot, is removed.
-    
-        Usage:
-            >> format_filename("john's portrait in 2004.jpg")
-            'johns_portrait_in_2004.jpg'
-            >> format_filename("something^_SD.dda.//fd/ad.exe")
-            'something_SD.dda.fdad.exe'
-            >> format_filename("Napoleon_:namespaces_GRP|group1_GRP")
-            'Napoleon_namespaces_GRPgroup1_GRP'
-    
-        """
-    
-        filename = filename.strip().replace(' ', '_')
-    
-        # on nt a couple of special files are present in each folder.  We
-        # have to ensure that the target file is not such a filename.  In
-        # this case we prepend an underline
-        if os.name == 'nt' and filename and \
-           filename.split('.')[0].upper() in _windows_device_files:
-            filename = '_' + filename
-    
-        return re.sub(r'(?u)[^-\w.]', '', filename)
-    
-    
-    def format_filename2(filename):
-        """Convert arbitrary string to valid filename, werkzeug-style.
-    
-        Modified from werkzeug.utils.secure_filename()
-    
-        Pass it a filename and it will return a secure version of it.  This
-        filename can then safely be stored on a regular file system and passed
-        to :func:`os.path.join`. The filename returned is an ASCII only string
-        for maximum portability.
-    
-        On windows system the function also makes sure that the file is not
-        named after one of the special device files.
-    
-        Arguments:
-            filename (str): the filename to secure
-    
-        Usage:
-            >> format_filename2("john's portrait in 2004.jpg")
-            'johns_portrait_in_2004.jpg'
-            >> format_filename2("something^_SD.dda.//fd/ad.exe")
-            'something_SD.dda._fd_ad.exe'
-            >> format_filename2("Napoleon_:namespaces_GRP|group1_GRP")
-            'Napoleon_namespaces_GRPgroup1_GRP'
-    
-        .. warning:: The function might return an empty filename.  It's your
-            responsibility to ensure that the filename is unique and that you
-            generate random filename if the function returned an empty one.
-    
-        .. versionadded:: 1.0.9
-    
-        """
-    
-        if isinstance(filename, six.text_type):
-            from unicodedata import normalize
-            filename = normalize('NFKD', filename).encode('ascii', 'ignore')
-    
-        for sep in os.path.sep, os.path.altsep:
-            if sep:
-                filename = filename.replace(sep, ' ')
-        filename = str(_filename_ascii_strip_re.sub('', '_'.join(
-                       filename.split()))).strip('._')
-    
-        # on nt a couple of special files are present in each folder.  We
-        # have to ensure that the target file is not such a filename.  In
-        # this case we prepend an underline
-        if os.name == 'nt' and filename and \
-           filename.split('.')[0].upper() in _windows_device_files:
-            filename = '_' + filename
-    
-        return filename
+@lib.deprecated
+def format_filename2(filename):
+    return filename
 
 
 lib.format_filename = format_filename

--- a/pyblish/compat.py
+++ b/pyblish/compat.py
@@ -2,6 +2,7 @@
 
 import warnings
 from . import plugin, lib
+from .vendor import six
 
 # Aliases
 Selector = plugin.Collector
@@ -121,3 +122,98 @@ def add(self, other):
 
 plugin.Context.create_asset = create_asset
 plugin.Context.add = add
+
+if six.PY3:
+    @lib.deprecated
+    def format_filename(filename):
+        pass
+
+
+    @lib.deprecated
+    def format_filename2(filename):
+        pass
+
+else:
+    def format_filename(filename):
+        """Convert arbitrary string to valid filename, django-style.
+    
+        Modified from django.utils.text.get_valid_filename()
+    
+        Returns the given string converted to a string that can be used for a clean
+        filename. Specifically, leading and trailing spaces are removed; other
+        spaces are converted to underscores; and anything that is not a unicode
+        alphanumeric, dash, underscore, or dot, is removed.
+    
+        Usage:
+            >> format_filename("john's portrait in 2004.jpg")
+            'johns_portrait_in_2004.jpg'
+            >> format_filename("something^_SD.dda.//fd/ad.exe")
+            'something_SD.dda.fdad.exe'
+            >> format_filename("Napoleon_:namespaces_GRP|group1_GRP")
+            'Napoleon_namespaces_GRPgroup1_GRP'
+    
+        """
+    
+        filename = filename.strip().replace(' ', '_')
+    
+        # on nt a couple of special files are present in each folder.  We
+        # have to ensure that the target file is not such a filename.  In
+        # this case we prepend an underline
+        if os.name == 'nt' and filename and \
+           filename.split('.')[0].upper() in _windows_device_files:
+            filename = '_' + filename
+    
+        return re.sub(r'(?u)[^-\w.]', '', filename)
+    
+    
+    def format_filename2(filename):
+        """Convert arbitrary string to valid filename, werkzeug-style.
+    
+        Modified from werkzeug.utils.secure_filename()
+    
+        Pass it a filename and it will return a secure version of it.  This
+        filename can then safely be stored on a regular file system and passed
+        to :func:`os.path.join`. The filename returned is an ASCII only string
+        for maximum portability.
+    
+        On windows system the function also makes sure that the file is not
+        named after one of the special device files.
+    
+        Arguments:
+            filename (str): the filename to secure
+    
+        Usage:
+            >> format_filename2("john's portrait in 2004.jpg")
+            'johns_portrait_in_2004.jpg'
+            >> format_filename2("something^_SD.dda.//fd/ad.exe")
+            'something_SD.dda._fd_ad.exe'
+            >> format_filename2("Napoleon_:namespaces_GRP|group1_GRP")
+            'Napoleon_namespaces_GRPgroup1_GRP'
+    
+        .. warning:: The function might return an empty filename.  It's your
+            responsibility to ensure that the filename is unique and that you
+            generate random filename if the function returned an empty one.
+    
+        .. versionadded:: 1.0.9
+    
+        """
+    
+        if isinstance(filename, six.text_type):
+            from unicodedata import normalize
+            filename = normalize('NFKD', filename).encode('ascii', 'ignore')
+    
+        for sep in os.path.sep, os.path.altsep:
+            if sep:
+                filename = filename.replace(sep, ' ')
+        filename = str(_filename_ascii_strip_re.sub('', '_'.join(
+                       filename.split()))).strip('._')
+    
+        # on nt a couple of special files are present in each folder.  We
+        # have to ensure that the target file is not such a filename.  In
+        # this case we prepend an underline
+        if os.name == 'nt' and filename and \
+           filename.split('.')[0].upper() in _windows_device_files:
+            filename = '_' + filename
+    
+        return filename
+

--- a/pyblish/compat.py
+++ b/pyblish/compat.py
@@ -1,5 +1,7 @@
 """Compatibility module"""
 
+import os
+import re
 import warnings
 from . import plugin, lib
 from .vendor import six
@@ -7,6 +9,10 @@ from .vendor import six
 # Aliases
 Selector = plugin.Collector
 Conformer = plugin.Integrator
+
+_filename_ascii_strip_re = re.compile(r'[^-\w.]')
+_windows_device_files = ('CON', 'AUX', 'COM1', 'COM2', 'COM3', 'COM4',
+                         'LPT1', 'LPT2', 'LPT3', 'PRN', 'NUL')
 
 
 def sort(*args, **kwargs):
@@ -217,3 +223,6 @@ else:
     
         return filename
 
+
+lib.format_filename = format_filename
+lib.format_filename2 = format_filename2

--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -8,6 +8,7 @@ import traceback
 import functools
 
 from . import _registered_callbacks
+from .vendor import six
 
 _filename_ascii_strip_re = re.compile(r'[^-\w.]')
 _windows_device_files = ('CON', 'AUX', 'COM1', 'COM2', 'COM3', 'COM4',
@@ -178,90 +179,6 @@ def parse_environment_paths(paths):
         paths_list.append(path)
 
     return paths_list
-
-
-def format_filename(filename):
-    """Convert arbitrary string to valid filename, django-style.
-
-    Modified from django.utils.text.get_valid_filename()
-
-    Returns the given string converted to a string that can be used for a clean
-    filename. Specifically, leading and trailing spaces are removed; other
-    spaces are converted to underscores; and anything that is not a unicode
-    alphanumeric, dash, underscore, or dot, is removed.
-
-    Usage:
-        >>> format_filename("john's portrait in 2004.jpg")
-        'johns_portrait_in_2004.jpg'
-        >>> format_filename("something^_SD.dda.//fd/ad.exe")
-        'something_SD.dda.fdad.exe'
-        >>> format_filename("Napoleon_:namespaces_GRP|group1_GRP")
-        'Napoleon_namespaces_GRPgroup1_GRP'
-
-    """
-
-    filename = filename.strip().replace(' ', '_')
-
-    # on nt a couple of special files are present in each folder.  We
-    # have to ensure that the target file is not such a filename.  In
-    # this case we prepend an underline
-    if os.name == 'nt' and filename and \
-       filename.split('.')[0].upper() in _windows_device_files:
-        filename = '_' + filename
-
-    return re.sub(r'(?u)[^-\w.]', '', filename)
-
-
-def format_filename2(filename):
-    """Convert arbitrary string to valid filename, werkzeug-style.
-
-    Modified from werkzeug.utils.secure_filename()
-
-    Pass it a filename and it will return a secure version of it.  This
-    filename can then safely be stored on a regular file system and passed
-    to :func:`os.path.join`. The filename returned is an ASCII only string
-    for maximum portability.
-
-    On windows system the function also makes sure that the file is not
-    named after one of the special device files.
-
-    Arguments:
-        filename (str): the filename to secure
-
-    Usage:
-        >>> format_filename2("john's portrait in 2004.jpg")
-        'johns_portrait_in_2004.jpg'
-        >>> format_filename2("something^_SD.dda.//fd/ad.exe")
-        'something_SD.dda._fd_ad.exe'
-        >>> format_filename2("Napoleon_:namespaces_GRP|group1_GRP")
-        'Napoleon_namespaces_GRPgroup1_GRP'
-
-    .. warning:: The function might return an empty filename.  It's your
-        responsibility to ensure that the filename is unique and that you
-        generate random filename if the function returned an empty one.
-
-    .. versionadded:: 1.0.9
-
-    """
-
-    if isinstance(filename, unicode):
-        from unicodedata import normalize
-        filename = normalize('NFKD', filename).encode('ascii', 'ignore')
-
-    for sep in os.path.sep, os.path.altsep:
-        if sep:
-            filename = filename.replace(sep, ' ')
-    filename = str(_filename_ascii_strip_re.sub('', '_'.join(
-                   filename.split()))).strip('._')
-
-    # on nt a couple of special files are present in each folder.  We
-    # have to ensure that the target file is not such a filename.  In
-    # this case we prepend an underline
-    if os.name == 'nt' and filename and \
-       filename.split('.')[0].upper() in _windows_device_files:
-        filename = '_' + filename
-
-    return filename
 
 
 def get_formatter():

--- a/pyblish/main.py
+++ b/pyblish/main.py
@@ -1,4 +1,4 @@
 import warnings
-from util import *
+from .util import *
 
 warnings.warn("main.py deprecated; use util.py")

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -34,13 +34,14 @@ from . import (
 )
 
 from . import lib
-from .vendor import iscompatible
-
+from .vendor import iscompatible, six
 
 log = logging.getLogger("pyblish.plugin")
 
+__metaclass__ = type  # Make all classes new-style
 
-class Provider(object):
+
+class Provider():
     """Dependency provider
 
     This object is given a series of "services" that it then distributes
@@ -185,7 +186,8 @@ class MetaPlugin(type):
 
 
 @lib.log
-class Plugin(object):
+@six.add_metaclass(MetaPlugin)
+class Plugin():
     """Base-class for plugins
 
     Attributes:
@@ -212,8 +214,6 @@ class Plugin(object):
         actions: Actions associated to this plug-in
 
     """
-
-    __metaclass__ = MetaPlugin
 
     hosts = ["*"]
     families = ["*"]
@@ -304,9 +304,8 @@ class ExplicitMetaPlugin(MetaPlugin):
         return super(ExplicitMetaPlugin, cls).__init__(*args, **kwargs)
 
 
+@six.add_metaclass(ExplicitMetaPlugin)
 class ContextPlugin(Plugin):
-
-    __metaclass__ = ExplicitMetaPlugin
 
     def process(self, context):
         """Primary processing method
@@ -317,9 +316,8 @@ class ContextPlugin(Plugin):
         """
 
 
+@six.add_metaclass(MetaPlugin)
 class InstancePlugin(Plugin):
-
-    __metaclass__ = ExplicitMetaPlugin
 
     def process(self, instance):
         """Primary processing method
@@ -352,7 +350,8 @@ class MetaAction(type):
 
 
 @lib.log
-class Action(object):
+@six.add_metaclass(MetaAction)
+class Action():
     """User-supplied interactive action
 
     Subclass this class and append to Plugin.actions in order
@@ -375,7 +374,6 @@ class Action(object):
 
     """
 
-    __metaclass__ = MetaAction
     __type__ = "action"
 
     label = None
@@ -656,7 +654,7 @@ class AbstractEntity(list):
     """
 
     def __init__(self, name, parent=None):
-        assert isinstance(name, basestring)
+        assert isinstance(name, six.string_types)
         assert parent is None or isinstance(parent, AbstractEntity)
 
         # Read-only properties
@@ -935,7 +933,7 @@ def register_service(name, obj):
 
     Arguments:
         name (str): Name of service
-        obj (object): Any object
+        obj (any): Any object
 
     """
 
@@ -1321,7 +1319,7 @@ def plugin_is_valid(plugin):
 
     """
 
-    if not isinstance(plugin.requires, basestring):
+    if not isinstance(plugin.requires, six.string_types):
         log.debug("Plug-in requires must be of type string: %s", plugin)
         return False
 
@@ -1334,12 +1332,12 @@ def plugin_is_valid(plugin):
         return False
 
     for family in plugin.families:
-        if not isinstance(family, basestring):
+        if not isinstance(family, six.string_types):
             log.debug("Families must be string")
             return False
 
     for host in plugin.hosts:
-        if not isinstance(host, basestring):
+        if not isinstance(host, six.string_types):
             log.debug("Hosts must be string")
             return False
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1234,7 +1234,8 @@ def discover(type=None, regex=None, paths=None):
             module.__file__ = abspath
 
             try:
-                execfile(abspath, module.__dict__)
+                with open(abspath) as f:
+                    six.exec_(f.read(), module.__dict__)
 
                 # Store reference to original module, to avoid
                 # garbage collection from collecting it's global

--- a/pyblish/vendor/six.py
+++ b/pyblish/vendor/six.py
@@ -1,0 +1,868 @@
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+# Copyright (c) 2010-2015 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.10.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    if from_value is None:
+        raise value
+    raise value from from_value
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    raise value from from_value
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(meta):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
+import os
+import imp
+
 from setuptools import setup, find_packages
 
 with open("README.txt") as f:
     readme = f.read()
 
-
-import os
-import imp
 
 version_file = os.path.abspath("pyblish/version.py")
 version_mod = imp.load_source("version", version_file)
@@ -13,7 +13,7 @@ version = version_mod.version
 
 
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Programming Language :: Python",
@@ -26,7 +26,7 @@ classifiers = [
 
 
 setup(
-    name="pyblish",
+    name="pyblish-base",
     version=version,
     description="Plug-in driven automation framework for content",
     long_description=readme,

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -3,11 +3,11 @@ import sys
 import shutil
 import tempfile
 import contextlib
-from StringIO import StringIO
 
 import pyblish
 import pyblish.cli
 import pyblish.plugin
+from pyblish.vendor import six
 
 # Setup
 HOST = 'python'
@@ -51,7 +51,7 @@ def teardown():
 def captured_stdout():
     """Temporarily reassign stdout to a local variable"""
     try:
-        sys.stdout = StringIO()
+        sys.stdout = six.StringIO()
         yield sys.stdout
     finally:
         sys.stdout = sys.__stdout__
@@ -61,7 +61,7 @@ def captured_stdout():
 def captured_stderr():
     """Temporarily reassign stderr to a local variable"""
     try:
-        sys.stderr = StringIO()
+        sys.stderr = six.StringIO()
         yield sys.stderr
     finally:
         sys.stderr = sys.__stderr__

--- a/tests/pre11/plugins/echo/select_echo.py
+++ b/tests/pre11/plugins/echo/select_echo.py
@@ -6,4 +6,4 @@ class SelectEcho(pyblish.Selector):
     version = (0, 0, 1)
 
     def process_context(self, context):
-        print context.data()
+        print(context.data())

--- a/tests/pre11/plugins/extract_documents.py
+++ b/tests/pre11/plugins/extract_documents.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import pyblish.api
 
-
 @pyblish.api.log
 class ExtractDocuments(pyblish.api.Extractor):
     """Extract instances"""
@@ -15,7 +14,7 @@ class ExtractDocuments(pyblish.api.Extractor):
         temp_dir = tempfile.mkdtemp()
 
         for document in instance:
-            for name, content in document.iteritems():
+            for name, content in document.items():
                 temp_file = os.path.join(temp_dir,
                                          '{0}.txt'.format(name))
                 with open(temp_file, 'w') as f:

--- a/tests/pre11/plugins/select_instances.py
+++ b/tests/pre11/plugins/select_instances.py
@@ -20,6 +20,6 @@ class SelectInstances(pyblish.api.Selector):
                 'family': 'test',
                 'startFrame': 1001,
                 'endFrame': 1025
-                }.iteritems():
+                }.items():
 
             instance.set_data(key, value)

--- a/tests/pre11/test_cli.py
+++ b/tests/pre11/test_cli.py
@@ -4,6 +4,8 @@ import pyblish
 import pyblish.cli
 import pyblish.api
 
+from pyblish.vendor import six
+
 from . import lib
 
 from pyblish.vendor.click.testing import CliRunner
@@ -45,10 +47,10 @@ def test_all_commands_run():
 def test_paths():
     """Paths are correctly returned from cli"""
     plugin = pyblish.api
-    for flag, func in {
+    for flag, func in six.iteritems({
             "--paths": plugin.plugin_paths,
             "--registered-paths": plugin.registered_paths,
-            "--environment-paths": plugin.environment_paths}.iteritems():
+            "--environment-paths": plugin.environment_paths}):
 
         print("Flag: %s" % flag)
         runner = CliRunner()

--- a/tests/pre11/test_logic.py
+++ b/tests/pre11/test_logic.py
@@ -355,7 +355,7 @@ def test_interface():
             context=context):
 
         if isinstance(result, pyblish.logic.TestFailed):
-            print result
+            print(result)
 
         if isinstance(result, Exception):
             raise result
@@ -410,7 +410,7 @@ def test_failing_validator():
         context=context)
     result = next(iterator)
     error = result["error"]
-    assert_equal(error.message, "instance failed")
+    assert_equal(str(error), "instance failed")
     assert_true(hasattr(error, "traceback"))
 
 
@@ -576,7 +576,7 @@ def test_repair():
             func=pyblish.plugin.repair,
             plugins=repair,
             context=context):
-        print result
+        print(result)
 
     assert_false(_data["broken"])
 

--- a/tests/pre13/test_di.py
+++ b/tests/pre13/test_di.py
@@ -27,7 +27,7 @@ def test_di():
                 instance.set_data("family", "myFamily")
                 instance.set_data("value", "123")
 
-            print "Instance: %s" % instance
+            print("Instance: %s" % instance)
 
     class ValidateInstance(pyblish.api.Validator):
         def process(self, instance):
@@ -209,7 +209,7 @@ def test_unavailable_service_logic():
 
     class SelectUnavailable(pyblish.api.Selector):
         def process(self, unavailable):
-            print "HHOH"
+            print("HHOH")
             self.log.critical("Test")
 
     for result in pyblish.logic.process(
@@ -265,7 +265,7 @@ def test_when_to_trigger_process():
         families = ["incompatibleFamily"]
 
         def process(self, instance):
-            print "Instance is: %s" % instance
+            print("Instance is: %s" % instance)
             _data["error"] = True
             assert False, "I should not have been run"
 
@@ -326,7 +326,7 @@ def test_asset():
             func=pyblish.plugin.process,
             plugins=[SelectCharacters, ValidateColor],
             context=pyblish.api.Context()):
-        print result
+        print(result)
 
     assert_equals(count["#"], 3)
 

--- a/tests/pre13/test_logic.py
+++ b/tests/pre13/test_logic.py
@@ -114,7 +114,7 @@ def test_repair():
             func=pyblish.plugin.repair,
             plugins=repair,
             context=context):
-        print result
+        print(result)
 
     assert_false(_data["broken"])
 
@@ -194,7 +194,7 @@ def test_custom_test():
     count = {"#": 0}
 
     def custom_test(**vars):
-        print "I accept anything"
+        print("I accept anything")
         return
 
     class MyValidator(pyblish.api.Validator):
@@ -203,7 +203,7 @@ def test_custom_test():
 
     class MyExtractor(pyblish.api.Extractor):
         def process(self, context):
-            print "I came, I saw, I extracted.."
+            print("I came, I saw, I extracted..")
             count["#"] += 1
 
     pyblish.api.register_test(custom_test)
@@ -390,8 +390,7 @@ def test_extract_traceback():
     except Exception as e:
         assert not hasattr(e, "traceback")
         pyblish.logic._extract_traceback(e)
-
-    assert hasattr(e, "traceback")
+        assert hasattr(e, "traceback")
 
 
 def test_plugins_by_families():

--- a/tests/pre13/test_plugin.py
+++ b/tests/pre13/test_plugin.py
@@ -9,6 +9,8 @@ from nose.tools import (
     assert_true,
 )
 
+from pyblish.vendor import six
+
 from .. import lib
 
 
@@ -62,7 +64,7 @@ class BadFamilies2(pyblish.api.Plugin):
 
 """
 
-    exec code in module.__dict__
+    six.exec_(code, module.__dict__)
 
     plugins = pyblish.plugin.plugins_from_module(module)
 
@@ -95,7 +97,7 @@ class MyPlugin(pyblish.api.Plugin):
 
 """
 
-    exec code in module.__dict__
+    six.exec_(code, module.__dict__)
     MyPlugin = pyblish.plugin.plugins_from_module(module)[0]
     assert MyPlugin.__name__ == "MyPlugin"
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -232,7 +232,7 @@ def test_unique_logger():
     context = pyblish.util.publish()
 
     assert_equals(count["#"], 1)
-    print context.data("results")
+    print(context.data("results"))
 
     results = context.data("results")[0]
     records = results["records"]
@@ -368,7 +368,7 @@ def test_action_printing():
         pass
 
     print(MyAction())
-    print repr(MyAction())
+    print(repr(MyAction()))
 
     assert str(MyAction()) == "MyAction"
     assert repr(MyAction()) == "pyblish.plugin.MyAction('MyAction')"
@@ -448,14 +448,15 @@ def test_register_callback():
 def test_emit_signal_wrongly():
     """Exception from callback prints traceback"""
 
-    def other_callback(data=None):
-        print "Ping from 'other_callback' with %s" % data
+    def other_callback(an_argument=None):
+        print("Ping from 'other_callback' with %s" % an_argument)
 
     pyblish.plugin.register_callback("otherSignal", other_callback)
 
     with lib.captured_stderr() as stderr:
-        pyblish.lib.emit("otherSignal", akeyword="")
+        pyblish.lib.emit("otherSignal", not_an_argument="")
         output = stderr.getvalue().strip()
+        print("Output: %s" % stderr.getvalue())
         assert output.startswith("Traceback")
 
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -7,7 +7,7 @@ from nose.tools import (
     with_setup
 )
 
-import lib
+from . import lib
 
 
 @with_setup(lib.setup_empty, lib.teardown)
@@ -136,6 +136,6 @@ def test_simple_order():
             func=pyblish.plugin.process,
             plugins=plugins,
             context=context):
-        print result
+        print(result)
 
     assert_equals(order, [1, 2, 3, 4])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,7 +19,7 @@ def test_multiple_instance_util_publish():
     count = {"#": 0}
 
     class MyContextCollector(pyblish.api.ContextPlugin):
-    	order = pyblish.api.CollectorOrder
+        order = pyblish.api.CollectorOrder
         def process(self, context):
             context.create_instance("A")
             context.create_instance("B")
@@ -27,9 +27,9 @@ def test_multiple_instance_util_publish():
 
 
     class MyInstancePluginCollector(pyblish.api.InstancePlugin):
-    	order = pyblish.api.CollectorOrder + 0.1
+        order = pyblish.api.CollectorOrder + 0.1
         def process(self, instance):
-        	count["#"] += 1
+            count["#"] += 1
 
 
     pyblish.api.register_plugin(MyContextCollector)


### PR DESCRIPTION
This is an ongoing Pull Request for work to implement support for Python 3.

It includes `six` and a few patches to the overall project, but a large number of tests still fail. Most of these issues are expected to be cosmetic, with the exception of the `discover()` dependency on `execfile` which has been removed from Python 3.

Motivation for this can be found in issue #234.

What you can do, is have a look at what fails currently and what can be done to resolve it. The goal is for Pyblish to be written in Python 3, with Python 2 support, rather than the other way around. So when monkeypatching is required, it is Python 2 which must be monkeypatched to resemble Python 3.
