### PR TITLE
register_gui()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+### Contributing to Qt
+
+To contribute, fork this project and submit a pull-request.
+
+Your code will be reviewed and merged once it:
+
+1. Does something useful
+1. Is up to par with surrounding code
+
+Development for this project takes place in individual forks. The parent project ever only contains a single branch, a branch containing the latest working version of the project.
+
+Bugreports must include:
+
+1. Description
+2. Expected results
+3. Short reproducible
+ 
+Feature requests must include:
+
+1. Goal (what the feature aims to solve)
+2. Motivation (why *you* think this is necessary)
+3. Suggested implementation (psuedocode)
+
+Questions may also be submitted as issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-### Contributing to Qt
+### Contributing to this project
 
 To contribute, fork this project and submit a pull-request.
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,63 @@
 [![Coverage Status][cover-image]][cover-link]
 [![PyPI version][pypi-image]][pypi-link]
 [![Code Health][landscape-image]][landscape-repo]
-[![Gitter][gitter-image]][chat]
+[![Gitter][gitter-image]](https://gitter.im/pyblish/pyblish?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![image](https://cloud.githubusercontent.com/assets/2152766/12704326/b6ff015c-c850-11e5-91be-68d824526f13.png)](https://www.youtube.com/watch?v=j5uUTW702-U)
 
 Test-driven content creation for collaborative, creative projects.
 
-- [Wiki][wiki]
-- [Learn by Example][example]
+- [Wiki](../wiki)
+- [Learn by Example](http://learn.pyblish.com)
 
-[example]: http://forums.pyblish.com/t/learning-pyblish-by-example/108
-[wiki]: https://github.com/pyblish/pyblish-base/wiki
-[chat]: https://gitter.im/pyblish/pyblish?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+<br>
+<br>
+<br>
+
+### Introduction
+
+Pyblish is a modular framework, consisting of many sub-projects. This project contains the primary API upon which all other projects build.
+
+You may use this project as-is, or in conjunction with surrounding projects - such as [pyblish-maya][] for integration with Autodesk Maya, [pyblish-qml][] for a visual front-end and [pyblish-magenta][] for a starting point your publishing pipeline.
+
+[pyblish-maya]: https://github.com/pyblish/pyblish-maya
+[pyblish-qml]: https://github.com/pyblish/pyblish-qml
+[pyblish-magenta]: https://github.com/pyblish/pyblish-magenta
+
+- [Browse All Projects](https://github.com/pyblish)
+
+<br>
+<br>
+<br>
+
+### Installation
+
+pyblish-base is avaialble on PyPI.
+
+```bash
+$ pip install pyblish-base
+```
+
+Like all other Pyblish projects, it may also be clone as-is via Git and added to your PYTHONPATH.
+
+```bash
+$ git clone https://github.com/pyblish/pyblish-base.git
+$ # Windows
+$ set PYTHONPATH=%cd%\pyblish-base
+$ # Unix
+$ export PYTHONPATH=$(pwd)/pyblish-base
+```
+
+<br>
+<br>
+<br>
+
+### Usage
+
+Refer to the [getting started guide](http://learn.pyblish.com) for a gentle introduction to the framework and [the forums](http://forums.pyblish.com) for tips and tricks.
+
+- [Learn Pyblish By Example](http://learn.pyblish.com)
+- [Forums](http://forums.pyblish.com)
 
 [travis-image]: https://travis-ci.org/pyblish/pyblish-base.svg?branch=master
 [travis-link]: https://travis-ci.org/pyblish/pyblish-base

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Test-driven content creation for collaborative, creative projects.
 
-- [Wiki](../wiki)
+- [Wiki](../../wiki)
 - [Learn by Example](http://learn.pyblish.com)
 
 <br>

--- a/pyblish/__init__.py
+++ b/pyblish/__init__.py
@@ -16,6 +16,7 @@ _registered_services = dict()
 _registered_test = dict()
 _registered_hosts = list()
 _registered_targets = list()
+_registered_gui = list()
 
 
 __all__ = [
@@ -29,4 +30,5 @@ __all__ = [
     "_registered_test",
     "_registered_hosts",
     "_registered_targets",
+    "_registered_gui",
 ]

--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -210,6 +210,12 @@ __all__ = [
     "plugins_by_instance",
     "instances_by_plugin",
 
+    "current_target",
+    "register_target",
+    "registered_targets",
+    "deregister_target",
+    "deregister_all_targets",
+
     "sort_plugins",
     "format_filename",
     "current_host",

--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -96,6 +96,11 @@ from .logic import (
     register_test,
     deregister_test,
     registered_test,
+
+    register_gui,
+    registered_guis,
+    deregister_gui,
+
     default_test as __default_test,
 )
 
@@ -204,6 +209,10 @@ __all__ = [
     "register_test",
     "deregister_test",
     "registered_test",
+
+    "register_gui",
+    "registered_guis",
+    "deregister_gui",
 
     "plugins_by_family",
     "plugins_by_host",

--- a/pyblish/compat.py
+++ b/pyblish/compat.py
@@ -1,10 +1,8 @@
 """Compatibility module"""
 
-import os
 import re
 import warnings
 from . import plugin, lib
-from .vendor import six
 
 # Aliases
 Selector = plugin.Collector
@@ -128,6 +126,7 @@ def add(self, other):
 
 plugin.Context.create_asset = create_asset
 plugin.Context.add = add
+
 
 @lib.deprecated
 def format_filename(filename):

--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -1,5 +1,4 @@
 import os
-import re
 import sys
 import logging
 import datetime
@@ -237,8 +236,10 @@ def emit(signal, **kwargs):
 
     Example:
         >>> import sys
-        >>> from .plugin import register_callback
-        >>> register_callback("mysignal", lambda data: sys.stdout.write(str(data)))
+        >>> from . import plugin
+        >>> plugin.register_callback(
+        ...   "mysignal", lambda data: sys.stdout.write(str(data)))
+        ...
         >>> emit("mysignal", data={"something": "cool"})
         {'something': 'cool'}
 
@@ -252,13 +253,14 @@ def emit(signal, **kwargs):
             traceback.print_exc(file=file)
             sys.stderr.write(file.getvalue())
             # Why the roundabout through StringIO?
-            # 
+            #
             # tests.lib.captured_stderr attempts to capture stderr
             # but doing so with plain print_exc() results in a type
             # error in Python 3. I'm not confident in Python 3 unicode
             # handling so there is likely a better way to solve this.
             #
             # TODO(marcus): Make it prettier
+
 
 def deprecated(func):
     """Deprecation decorator

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,12 @@ classifiers = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.6",
     "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.1",
+    "Programming Language :: Python :: 3.2",
+    "Programming Language :: Python :: 3.3",
+    "Programming Language :: Python :: 3.4",
+    "Programming Language :: Python :: 3.5",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities"
 ]
@@ -31,7 +37,7 @@ setup(
     description="Plug-in driven automation framework for content",
     long_description=readme,
     author="Abstract Factory and Contributors",
-    author_email="marcus@abstractfactory.com",
+    author_email="marcus@abstractfactory.io",
     url="https://github.com/pyblish/pyblish",
     license="LGPL",
     packages=find_packages(),
@@ -40,7 +46,6 @@ setup(
     package_data={
         "pyblish": ["plugins/*.py",
                     "*.yaml",
-                    "vendor/nose/*.txt",
                     "icons/*.svg"],
     },
     entry_points={


### PR DESCRIPTION
### Goal

Enable use of multiple GUIs and eliminate dependency on pyblish-integration and pyblish-qml from host integration packages, like pyblish-maya.
### Implementation

A new function is introduced, where a developer may build a GUI and register it with Pyblish. An integration may then query registered GUIs and attempt to open the most suitable one.
- http://api.pyblish.com/register_gui.html

Also see:
- https://github.com/pyblish/pyblish-qml/pull/204
- https://github.com/pyblish/pyblish-maya/pull/57
