### PR TITLE
Implement #282

### DIFF
--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,55 @@
+
+# Local library
+from . import lib
+
+from pyblish import api, logic, plugin
+
+from nose.tools import (
+    with_setup
+)
+
+
+@with_setup(lib.setup, lib.teardown)
+def test_iterator():
+    """Iterator skips inactive plug-ins and instances"""
+
+    count = {"#": 0}
+
+    class MyCollector(api.ContextPlugin):
+        order = api.CollectorOrder
+
+        def process(self, context):
+            inactive = context.create_instance("Inactive")
+            active = context.create_instance("Active")
+
+            inactive.data["publish"] = False
+            active.data["publish"] = True
+
+            count["#"] += 1
+
+    class MyValidatorA(api.InstancePlugin):
+        order = api.ValidatorOrder
+        active = False
+
+        def process(self, instance):
+            count["#"] += 10
+
+    class MyValidatorB(api.InstancePlugin):
+        order = api.ValidatorOrder
+
+        def process(self, instance):
+            count["#"] += 100
+
+    context = api.Context()
+    plugins = [MyCollector, MyValidatorA, MyValidatorB]
+
+    assert count["#"] == 0, count
+
+    for Plugin, instance in logic.Iterator(plugins, context):
+        assert instance.name != "Inactive" if instance else True
+        assert Plugin.__name__ != "MyValidatorA"
+
+        plugin.process(Plugin, context, instance)
+
+    # Collector runs once, one Validator runs once
+    assert count["#"] == 101, count


### PR DESCRIPTION
Also moved this responsibility into the Iterator, now no GUI will need to self-implement this such that all implementations will have a more aligned behavior.

Also added log messages at DEBUG level that can be enabled like so.

``` python
import logging
logging.getLogger("pyblish").setLevel(logging.DEBUG)
```

These will tell you when (1) a plug-in is skipped due to being `active=False` and (2) when an instance is skipped due to `data["publish"] = False`.
