### PR TITLE
Rename Callback to Handler

### DIFF
--- a/pyblish/__init__.py
+++ b/pyblish/__init__.py
@@ -10,7 +10,7 @@ from .version import version, version_info, __version__
 
 
 _registered_paths = list()
-_registered_callbacks = dict()
+_registered_handlers = dict()
 _registered_plugins = dict()
 _registered_services = dict()
 _registered_test = dict()
@@ -24,7 +24,7 @@ __all__ = [
     "version_info",
     "__version__",
     "_registered_paths",
-    "_registered_callbacks",
+    "_registered_handlers",
     "_registered_plugins",
     "_registered_services",
     "_registered_test",

--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -69,10 +69,10 @@ from .plugin import (
     deregister_all_services,
     registered_services,
 
-    register_callback,
-    deregister_callback,
-    deregister_all_callbacks,
-    registered_callbacks,
+    register_handler,
+    deregister_handler,
+    deregister_all_handlers,
+    registered_handlers,
 
     sort as sort_plugins,
 
@@ -119,6 +119,11 @@ from .compat import (
     Selector,
     Conformer,
     format_filename,
+
+    register_callback,
+    deregister_callback,
+    deregister_all_callbacks,
+    registered_callbacks,
 )
 
 
@@ -144,6 +149,7 @@ def __init__():
 
     # Register default test
     register_test(__default_test)
+
 
 __init__()
 
@@ -197,10 +203,10 @@ __all__ = [
     "deregister_all_services",
     "registered_services",
 
-    "register_callback",
-    "deregister_callback",
-    "deregister_all_callbacks",
-    "registered_callbacks",
+    "register_handler",
+    "deregister_handler",
+    "deregister_all_handlers",
+    "registered_handlers",
 
     "register_plugin_path",
     "deregister_plugin_path",
@@ -247,4 +253,9 @@ __all__ = [
     # Compatibility
     "deregister_all",
     "sort",
+
+    "register_callback",
+    "deregister_callback",
+    "deregister_all_callbacks",
+    "registered_callbacks",
 ]

--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -77,6 +77,7 @@ from .plugin import (
 )
 
 from .lib import (
+    on,
     log,
     time as __time,
     emit,
@@ -203,6 +204,8 @@ __all__ = [
     "deregister_service",
     "deregister_all_services",
     "registered_services",
+
+    "on",
 
     "register_handler",
     "deregister_handler",

--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -69,11 +69,6 @@ from .plugin import (
     deregister_all_services,
     registered_services,
 
-    register_handler,
-    deregister_handler,
-    deregister_all_handlers,
-    registered_handlers,
-
     sort as sort_plugins,
 
     registered_paths,
@@ -85,8 +80,14 @@ from .lib import (
     log,
     time as __time,
     emit,
-    main_package_path as __main_package_path
+    main_package_path as __main_package_path,
+
+    register_handler,
+    deregister_handler,
+    deregister_all_handlers,
+    registered_handlers,
 )
+
 
 from .logic import (
     plugins_by_family,

--- a/pyblish/compat.py
+++ b/pyblish/compat.py
@@ -266,7 +266,7 @@ process.next_instance = None
 logic.process = process
 
 # Backwards compatibility
-plugin.register_callback = plugin.register_handler
-plugin.deregister_callback = plugin.deregister_handler
-plugin.registered_callbacks = plugin.registered_handlers
-plugin.deregister_all_callbacks = plugin.deregister_all_handlers
+lib.register_callback = lib.register_handler
+lib.deregister_callback = lib.deregister_handler
+lib.registered_callbacks = lib.registered_handlers
+lib.deregister_all_callbacks = lib.deregister_all_handlers

--- a/pyblish/compat.py
+++ b/pyblish/compat.py
@@ -264,3 +264,9 @@ process.next_plugin = None
 process.next_instance = None
 
 logic.process = process
+
+# Backwards compatibility
+plugin.register_callback = plugin.register_handler
+plugin.deregister_callback = plugin.deregister_handler
+plugin.registered_callbacks = plugin.registered_handlers
+plugin.deregister_all_callbacks = plugin.deregister_all_handlers

--- a/pyblish/compat.py
+++ b/pyblish/compat.py
@@ -265,8 +265,7 @@ process.next_instance = None
 
 logic.process = process
 
-# Backwards compatibility
-lib.register_callback = lib.register_handler
-lib.deregister_callback = lib.deregister_handler
-lib.registered_callbacks = lib.registered_handlers
-lib.deregister_all_callbacks = lib.deregister_all_handlers
+register_callback = lib.register_handler
+deregister_callback = lib.deregister_handler
+registered_callbacks = lib.registered_handlers
+deregister_all_callbacks = lib.deregister_all_handlers

--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -6,7 +6,7 @@ import warnings
 import traceback
 import functools
 
-from . import _registered_callbacks
+from . import _registered_handlers
 from .vendor import six
 
 
@@ -245,7 +245,7 @@ def emit(signal, **kwargs):
 
     """
 
-    for callback in _registered_callbacks.get(signal, []):
+    for callback in _registered_handlers.get(signal, []):
         try:
             callback(**kwargs)
         except Exception:

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -14,12 +14,12 @@ with "validate" and ends with ".py"
 import os
 import sys
 import time
+import uuid
 import types
 import logging
 import inspect
 import warnings
 import contextlib
-import uuid
 
 # Local library
 from . import (
@@ -836,59 +836,6 @@ def current_host():
     """
 
     return _registered_hosts[-1] if _registered_hosts else "unknown"
-
-
-def on(signal, handler):
-    """Convenience function for register_handler"""
-    register_handler(signal, handler)
-
-
-def register_handler(signal, handler):
-    """Register a new handler
-
-    Arguments:
-        signal (string): Name of signal to register the handler with.
-        handler (func): Function to execute when a signal is emitted.
-
-    Raises:
-        ValueError if `handler` is not callable.
-
-    """
-
-    if not hasattr(handler, "__call__"):
-        raise ValueError("%s is not callable" % handler)
-
-    if signal in _registered_handlers:
-        _registered_handlers[signal].append(handler)
-    else:
-        _registered_handlers[signal] = [handler]
-
-
-def deregister_handler(signal, handler):
-    """Deregister a handler
-
-    Arguments:
-        signal (string): Name of signal to deregister the handler with.
-        handler (func): Function to execute when a signal is emitted.
-
-    Raises:
-        KeyError on missing signal
-        ValueError on missing handler
-    """
-
-    _registered_handlers[signal].remove(handler)
-
-
-def deregister_all_handlers():
-    """Deregisters all handler"""
-
-    _registered_handlers.clear()
-
-
-def registered_handlers():
-    """Returns registered handlers"""
-
-    return _registered_handlers
 
 
 def register_plugin(plugin):

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -25,7 +25,7 @@ import uuid
 from . import (
     __version__,
     version_info,
-    _registered_callbacks,
+    _registered_handlers,
     _registered_services,
     _registered_plugins,
     _registered_hosts,
@@ -838,52 +838,57 @@ def current_host():
     return _registered_hosts[-1] if _registered_hosts else "unknown"
 
 
-def register_callback(signal, callback):
-    """Register a new callback
+def on(signal, handler):
+    """Convenience function for register_handler"""
+    register_handler(signal, handler)
+
+
+def register_handler(signal, handler):
+    """Register a new handler
 
     Arguments:
-        signal (string): Name of signal to register the callback with.
-        callback (func): Function to execute when a signal is emitted.
+        signal (string): Name of signal to register the handler with.
+        handler (func): Function to execute when a signal is emitted.
 
     Raises:
-        ValueError if `callback` is not callable.
+        ValueError if `handler` is not callable.
 
     """
 
-    if not hasattr(callback, "__call__"):
-        raise ValueError("%s is not callable" % callback)
+    if not hasattr(handler, "__call__"):
+        raise ValueError("%s is not callable" % handler)
 
-    if signal in _registered_callbacks:
-        _registered_callbacks[signal].append(callback)
+    if signal in _registered_handlers:
+        _registered_handlers[signal].append(handler)
     else:
-        _registered_callbacks[signal] = [callback]
+        _registered_handlers[signal] = [handler]
 
 
-def deregister_callback(signal, callback):
-    """Deregister a callback
+def deregister_handler(signal, handler):
+    """Deregister a handler
 
     Arguments:
-        signal (string): Name of signal to deregister the callback with.
-        callback (func): Function to execute when a signal is emitted.
+        signal (string): Name of signal to deregister the handler with.
+        handler (func): Function to execute when a signal is emitted.
 
     Raises:
         KeyError on missing signal
-        ValueError on missing callback
+        ValueError on missing handler
     """
 
-    _registered_callbacks[signal].remove(callback)
+    _registered_handlers[signal].remove(handler)
 
 
-def deregister_all_callbacks():
-    """Deregisters all callback"""
+def deregister_all_handlers():
+    """Deregisters all handler"""
 
-    _registered_callbacks.clear()
+    _registered_handlers.clear()
 
 
-def registered_callbacks():
-    """Returns registered callbacks"""
+def registered_handlers():
+    """Returns registered handlers"""
 
-    return _registered_callbacks
+    return _registered_handlers
 
 
 def register_plugin(plugin):

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 4
-VERSION_PATCH = 2
+VERSION_PATCH = 3
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -5,15 +5,15 @@ import tempfile
 import contextlib
 
 import pyblish
+import pyblish.api
 import pyblish.cli
-import pyblish.plugin
 from pyblish.vendor import six
 
 # Setup
 HOST = 'python'
 FAMILY = 'test.family'
 
-REGISTERED = pyblish.plugin.registered_paths()
+REGISTERED = pyblish.api.registered_paths()
 PACKAGEPATH = pyblish.lib.main_package_path()
 ENVIRONMENT = os.environ.get("PYBLISHPLUGINPATH", "")
 PLUGINPATH = os.path.join(PACKAGEPATH, '..', 'tests', 'plugins')
@@ -21,24 +21,24 @@ PLUGINPATH = os.path.join(PACKAGEPATH, '..', 'tests', 'plugins')
 
 def setup():
     """Disable default plugins and only use test plugins"""
-    pyblish.plugin.deregister_all_paths()
+    pyblish.api.deregister_all_paths()
 
 
 def setup_empty():
     """Disable all plug-ins"""
     setup()
-    pyblish.plugin.deregister_all_plugins()
-    pyblish.plugin.deregister_all_paths()
-    pyblish.plugin.deregister_all_hosts()
-    pyblish.plugin.deregister_all_callbacks()
+    pyblish.api.deregister_all_plugins()
+    pyblish.api.deregister_all_paths()
+    pyblish.api.deregister_all_hosts()
+    pyblish.api.deregister_all_callbacks()
 
 
 def teardown():
     """Restore previously REGISTERED paths"""
 
-    pyblish.plugin.deregister_all_paths()
+    pyblish.api.deregister_all_paths()
     for path in REGISTERED:
-        pyblish.plugin.register_plugin_path(path)
+        pyblish.api.register_plugin_path(path)
 
     os.environ["PYBLISHPLUGINPATH"] = ENVIRONMENT
     pyblish.api.deregister_all_plugins()

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -30,7 +30,7 @@ def setup_empty():
     pyblish.api.deregister_all_plugins()
     pyblish.api.deregister_all_paths()
     pyblish.api.deregister_all_hosts()
-    pyblish.api.deregister_all_callbacks()
+    pyblish.api.deregister_all_handlers()
 
 
 def teardown():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,7 +2,6 @@ import pyblish.api
 import pyblish.util
 from nose.tools import (
     with_setup,
-    assert_in,
     assert_raises,
     assert_equals,
 )
@@ -137,7 +136,7 @@ def test_register_handler():
 
     pyblish.api.on("mySignal", my_handler)
 
-    assert_in("mySignal", pyblish.api.registered_handlers())
+    assert "mySignal" in pyblish.api.registered_handlers()
 
     pyblish.api.deregister_handler("mySignal", my_handler)
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,6 +2,9 @@ import pyblish.api
 import pyblish.util
 from nose.tools import (
     with_setup,
+    assert_in,
+    assert_raises,
+    assert_equals,
 )
 from . import lib
 
@@ -16,7 +19,7 @@ def test_published_event():
         assert isinstance(context, pyblish.api.Context)
         count["#"] += 1
 
-    pyblish.api.register_callback("published", on_published)
+    pyblish.api.on("published", on_published)
     pyblish.util.publish()
 
     assert count["#"] == 1, count
@@ -32,14 +35,19 @@ def test_validated_event():
         assert isinstance(context, pyblish.api.Context)
         count["#"] += 1
 
-    pyblish.api.register_callback("validated", on_validated)
+    pyblish.api.on("validated", on_validated)
     pyblish.util.validate()
 
     assert count["#"] == 1, count
 
+
 @with_setup(lib.setup_empty)
 def test_plugin_processed_event():
-    """pluginProcessed is emitted upon a plugin being processed, regardless of its success"""
+    """pluginProcessed is emitted upon a plugin being processed
+
+    It is emitted regardless of success.
+
+    """
 
     class MyContextCollector(pyblish.api.ContextPlugin):
         order = pyblish.api.CollectorOrder
@@ -63,17 +71,17 @@ def test_plugin_processed_event():
     pyblish.api.register_plugin(CheckInstancePass)
     pyblish.api.register_plugin(CheckInstanceFail)
 
-
     count = {"#": 0}
 
     def on_processed(result):
         assert isinstance(result, dict)
         count["#"] += 1
 
-    pyblish.api.register_callback("pluginProcessed", on_processed)
+    pyblish.api.on("pluginProcessed", on_processed)
     pyblish.util.publish()
 
     assert count["#"] == 3, count
+
 
 @with_setup(lib.setup_empty)
 def test_plugin_failed_event():
@@ -81,16 +89,19 @@ def test_plugin_failed_event():
 
     class MyContextCollector(pyblish.api.ContextPlugin):
         order = pyblish.api.CollectorOrder
+
         def process(self, context):
             context.create_instance("A")
 
     class CheckInstancePass(pyblish.api.InstancePlugin):
         order = pyblish.api.ValidatorOrder
+
         def process(self, instance):
             pass
 
     class CheckInstanceFail(pyblish.api.InstancePlugin):
         order = pyblish.api.ValidatorOrder
+
         def process(self, instance):
             raise Exception("Test Fail")
 
@@ -101,14 +112,126 @@ def test_plugin_failed_event():
     count = {"#": 0}
 
     def on_failed(plugin, context, instance, error):
-        assert issubclass(plugin, pyblish.api.InstancePlugin) #plugin == CheckInstanceFail
+        assert issubclass(plugin, pyblish.api.InstancePlugin)
         assert isinstance(context, pyblish.api.Context)
         assert isinstance(instance, pyblish.api.Instance)
         assert isinstance(error, Exception)
 
         count["#"] += 1
 
-    pyblish.api.register_callback("pluginFailed", on_failed)
+    pyblish.api.on("pluginFailed", on_failed)
     pyblish.util.publish()
 
     assert count["#"] == 1, count
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_register_handler():
+    """Callback registration/deregistration works well"""
+
+    def my_handler():
+        pass
+
+    def other_handler(data=None):
+        pass
+
+    pyblish.api.on("mySignal", my_handler)
+
+    assert_in("mySignal", pyblish.api.registered_handlers())
+
+    pyblish.api.deregister_handler("mySignal", my_handler)
+
+    # The handler does not exist
+    assert_raises(KeyError,
+                  pyblish.api.deregister_handler,
+                  "mySignal", my_handler)
+
+    # The signal does not exist
+    assert_raises(KeyError,
+                  pyblish.api.deregister_handler,
+                  "notExist", my_handler)
+
+    assert_equals(pyblish.api.registered_handlers(), [])
+
+    pyblish.api.on("mySignal", my_handler)
+    pyblish.api.on("otherSignal", other_handler)
+    pyblish.api.deregister_all_handlers()
+
+    assert_equals(pyblish.api.registered_handlers(), [])
+
+
+def test_weak_handler():
+    """Callbacks have weak references"""
+
+    count = {"#": 0}
+
+    def my_handler():
+        count["#"] += 1
+
+    pyblish.api.on("on_handler", my_handler)
+    pyblish.api.emit("on_handler")
+    assert count["#"] == 1
+
+    del(my_handler)
+
+    pyblish.api.emit("on_handler")
+
+    # No errors were thrown, count did not increase
+    assert count["#"] == 1
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_emit_signal_wrongly():
+    """Exception from handler prints traceback"""
+
+    def other_handler(an_argument=None):
+        print("Ping from 'other_handler' with %s" % an_argument)
+
+    pyblish.api.on("otherSignal", other_handler)
+
+    with lib.captured_stderr() as stderr:
+        pyblish.lib.emit("otherSignal", not_an_argument="")
+        output = stderr.getvalue().strip()
+        print("Output: %s" % stderr.getvalue())
+        assert output.startswith("Traceback")
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_bound_handler():
+    """Handlers may be bound to a class"""
+
+    count = {"#": 0}
+
+    class MyObject(object):
+        def __init__(self):
+            pyblish.api.on("mySignal", self.on_mysignal)
+
+        def on_mysignal(self):
+            count["#"] += 1
+
+    obj = MyObject()
+    pyblish.api.emit("mySignal")
+    assert_equals(count["#"], 1)
+
+    obj  # Avoid usage warning
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_weak_bound_handler():
+
+    count = {"#": 0}
+
+    class MyObject(object):
+        def __init__(self):
+            pyblish.api.on("mySignal", self.on_mysignal)
+
+        def on_mysignal(self):
+            count["#"] += 1
+
+    obj = MyObject()
+    pyblish.api.emit("mySignal")
+    assert_equals(count["#"], 1)
+
+    del(obj)
+    pyblish.api.emit("mySignal")
+    assert_equals(count["#"], 1)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -8,7 +8,6 @@ from nose.tools import (
     assert_true,
     assert_equals,
     assert_raises,
-    assert_in,
     raises,
 )
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -405,88 +405,17 @@ def test_plugin_source_path():
     assert inspect.getfile(plugin) == module.__file__
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_register_callback():
-    """Callback registration/deregistration works well"""
-
-    def my_callback():
-        pass
-
-    def other_callback(data=None):
-        pass
-
-    pyblish.api.register_callback("mySignal", my_callback)
-
-    assert_in("mySignal", pyblish.api.registered_callbacks())
-
-    pyblish.api.deregister_callback("mySignal", my_callback)
-
-    # The callback does not exist
-    assert_raises(KeyError,
-                  pyblish.api.deregister_callback,
-                  "mySignal", my_callback)
-
-    # The signal does not exist
-    assert_raises(KeyError,
-                  pyblish.api.deregister_callback,
-                  "notExist", my_callback)
-
-    assert_equals(pyblish.api.registered_callbacks(), [])
-
-    pyblish.api.register_callback("mySignal", my_callback)
-    pyblish.api.register_callback("otherSignal", other_callback)
-    pyblish.api.deregister_all_callbacks()
-
-    assert_equals(pyblish.api.registered_callbacks(), [])
-
-
-def test_weak_callback():
-    """Callbacks have weak references"""
-
-    count = {"#": 0}
-
-    def my_callback():
-        count["#"] += 1
-
-    pyblish.api.register_callback("on_callback", my_callback)
-    pyblish.api.emit("on_callback")
-    assert count["#"] == 1
-
-    del(my_callback)
-
-    pyblish.api.emit("on_callback")
-
-    # No errors were thrown, count did not increase
-    assert count["#"] == 1
-
-
-@with_setup(lib.setup_empty, lib.teardown)
-def test_emit_signal_wrongly():
-    """Exception from callback prints traceback"""
-
-    def other_callback(an_argument=None):
-        print("Ping from 'other_callback' with %s" % an_argument)
-
-    pyblish.api.register_callback("otherSignal", other_callback)
-
-    with lib.captured_stderr() as stderr:
-        pyblish.lib.emit("otherSignal", not_an_argument="")
-        output = stderr.getvalue().strip()
-        print("Output: %s" % stderr.getvalue())
-        assert output.startswith("Traceback")
-
-
 @raises(ValueError)
 @with_setup(lib.setup_empty, lib.teardown)
-def test_registering_invalid_callback():
+def test_registering_invalid_handler():
     """Can't register non-callables"""
-    pyblish.api.register_callback("invalid", None)
+    pyblish.api.register_handler("invalid", None)
 
 
 @raises(KeyError)
-def test_deregistering_nonexisting_callback():
-    """Can't deregister a callback that doesn't exist"""
-    pyblish.api.deregister_callback("invalid", lambda: "")
+def test_deregistering_nonexisting_handler():
+    """Can't deregister a handler that doesn't exist"""
+    pyblish.api.deregister_handler("invalid", lambda: "")
 
 
 @raises(TypeError)


### PR DESCRIPTION
This PR implements `on`, and renames all references to `callback` to `handler`.
- #293 (Rename Callback to Handler)

**Full backwards compatibility is preserved**

<br>

### Example

Technically, `on` is simply an alias for `register_handler`, previously known ad `register_callback`.

``` python
from pyblish import api, util

def on_published(context):
  print("Published!")

api.on("published", on_published)

util.publish()
# Published!
```

<br>

### Explicit Support for Graphical User Interfaces.

In addition, this PR implements "weak references" for all event handlers.

This shouldn't have much effect on your day to day use of Pyblish, but will make a difference in a few small corner cases.

For example, consider this.

``` python
count = {"#": 0}

class MyObject(object):
    def __init__(self):
        pyblish.api.on("mySignal", self.on_mysignal)

    def on_mysignal(self):
        count["#"] += 1

obj = MyObject()
pyblish.api.emit("mySignal")
assert_equals(count["#"], 1)

del(obj)
pyblish.api.emit("mySignal")
assert_equals(count["#"], 1)
```

As you would expect, once the object is deleted, the handler stops being called. Prior to this PR however, `count["#"]` equalled `2`.

In practice, this could cause issues when you build a GUI around signals, and register methods within your GUI and then create a new instance of this GUI.

The second instance would reconnect to these signals, leaving the old methods in place, resulting in two calls per method. For each instance of your GUI, the calls would stack up, and off you go.

This PR enables you to build user interfaces that harness the signals produces throughout Pyblish, without worrying about these difficult-to-debug problems.
