### PR TITLE
fix for #301

### DIFF
--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -54,7 +54,8 @@ def publish(context=None, plugins=None):
     # least one compatible instance.
     for Plugin in list(plugins):
         if Plugin.__instanceEnabled__:
-            if not logic.instances_by_plugin(context, Plugin):
+            if (not logic.instances_by_plugin(context, Plugin) and
+                "*" not in Plugin.families):
                 plugins.remove(Plugin)
 
     # Mutable state, used in Iterator


### PR DESCRIPTION
Test code for context:

``` python
import pyblish.api

items = ["john", "door"]


class CollectInstances(pyblish.api.ContextPlugin):
    order = 10

    def process(self, context):
        for item in items:
            context.create_instance(item)


class PrintInstances(pyblish.api.InstancePlugin):
    order = 20

    def process(self, instance):
        print("Instance is: %s" % instance)

pyblish.api.register_plugin(CollectInstances)
pyblish.api.register_plugin(PrintInstances)

import pyblish.util
context = pyblish.util.publish()
```

The issue was that when collection had been run, it was assumed that all plugins would have instances to process with. This discarded the wildcard `*` for all families, resulting in all instance plugins operating with `*` in their families would be removed from processing.

In theory this behavior is correct in that if there aren't any instances to operate on, the plugin shouldn't actually run. So this will fix it, but I don't know whether it should be fixed.
