### PR TITLE
Variable family-matching algorithms

### DIFF
--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -27,6 +27,11 @@ from .plugin import (
     Category,
     Separator,
 
+    # Matching algorithms
+    Subset,
+    Intersection,
+    Exact,
+
     Asset,
     Plugin,
     Validator,

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -189,10 +189,10 @@ def plugins_by_instance(plugins, instance):
 
     """
 
-    family = instance.data["family"]
+    family = instance.data.get("family")
     families = instance.data.get("families", [])
 
-    return plugins_by_families(plugins, [family] + families)
+    return plugins_by_families(plugins, ([family] if family else []) + families)
 
 
 def plugins_by_host(plugins, host):
@@ -255,8 +255,8 @@ def instances_by_plugin(instances, plugin):
         assert algorithm, ("Plug-in did not provide "
                            "valid matching algorithm: %s" % plugin.match)
 
-        families = [instance.data["family"]]
-        families += instance.data.get("families", [])
+        family = instance.data.get("family")
+        families = ([family] if family else []) + instance.data.get("families", [])
 
         if algorithm(plugin.families, families):
             compatible.append(instance)

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -192,7 +192,8 @@ def plugins_by_instance(plugins, instance):
     family = instance.data.get("family")
     families = instance.data.get("families", [])
 
-    return plugins_by_families(plugins, ([family] if family else []) + families)
+    return plugins_by_families(
+        plugins, ([family] if family else []) + families)
 
 
 def plugins_by_host(plugins, host):
@@ -256,7 +257,8 @@ def instances_by_plugin(instances, plugin):
                            "valid matching algorithm: %s" % plugin.match)
 
         family = instance.data.get("family")
-        families = ([family] if family else []) + instance.data.get("families", [])
+        families = [family] if family else []
+        families += instance.data.get("families", [])
 
         if algorithm(plugin.families, families):
             compatible.append(instance)

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -241,7 +241,7 @@ def instances_by_plugin(instances, plugin):
     algorithm = {
         Intersection: lambda a, b: set(a).intersection(b),
         Subset: lambda a, b: set(a).issubset(b),
-        Exact: lambda a, b: a == b
+        Exact: lambda a, b: set(a) == set(b)
     }.get(plugin.match)
 
     compatible = list()

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -40,6 +40,11 @@ log = logging.getLogger("pyblish.plugin")
 
 __metaclass__ = type  # Make all classes new-style
 
+# Matching algorithms
+Intersection = 1 << 0
+Subset = 1 << 1
+Exact = 1 << 2
+
 
 class Provider():
     """Dependency provider
@@ -212,6 +217,11 @@ class Plugin():
             will not be loaded. 1.0.8 was when :attr:`Plugin.requires`
             was first introduced.
         actions: Actions associated to this plug-in
+        id: Unique ID as str
+        match: Family matching algorithm - Intersection, Subset or Exact
+            Intersection -> set(a).intersection(b)
+            Subset       -> set(a).issubset(b)
+            Exact        -> a == b
 
     """
 
@@ -225,6 +235,7 @@ class Plugin():
     requires = "pyblish>=1"
     actions = []
     id = None  # Defined by metaclass
+    match = Intersection # Default matching algorithm
 
     def __str__(self):
         return self.label or type(self).__name__
@@ -1363,6 +1374,15 @@ def plugin_is_valid(plugin):
 
     if hasattr(plugin, "__invalidSignature__"):
         log.debug("Invalid signature")
+        return False
+
+    if plugin.match not in (Intersection, Subset, Exact):
+        log.debug("'%s' not a supported family "
+                  "matching algorithm." % plugin.match)
+        log.debug("Options are "
+                  "pyblish.api.Intersection, "
+                  "pyblish.api.Subset and"
+                  "pyblish.api.Exact")
         return False
 
     return True

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 4
-VERSION_PATCH = 2
+VERSION_PATCH = 3
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -107,23 +107,12 @@ def test_subset_match():
 
 
 def test_subset_exact():
-    """Plugin.match = api.Exact works as expected
-
-    Notice the 'default' family in the plug-in. Instances are automatically
-    imbued with this family on creation, as value to their `data["family"]` key.
-
-    When using multiple families, it is common not to bother modifying `family`,
-    and in the future this member needn't be there at all and may/should be
-    removed. But till then, for complete clarity, it might be worth removing this
-    explicitly during the creation of instances if instead choosing to use the
-    `families` key.
-
-    """
+    """Plugin.match = api.Exact works as expected"""
 
     count = {"#": 0}
 
     class MyPlugin(api.InstancePlugin):
-        families = ["default", "a", "b"]
+        families = ["a", "b"]
         match = api.Exact
 
         def process(self, instance):
@@ -134,7 +123,16 @@ def test_subset_exact():
     context.create_instance("not_included_1", families=["a"])
     context.create_instance("not_included_1", families=["x"])
     context.create_instance("not_included_3", families=["a", "b", "c"])
-    context.create_instance("included_1", families=["a", "b"])
+    instance = context.create_instance("included_1", families=["a", "b"])
+
+    # Discard the solo-family member, which defaults to `default`.
+    #
+    # When using multiple families, it is common not to bother modifying `family`,
+    # and in the future this member needn't be there at all and may/should be
+    # removed. But till then, for complete clarity, it might be worth removing
+    # this explicitly during the creation of instances if instead choosing to
+    # use the `families` key.
+    instance.data.pop("family")
 
     util.publish(context, plugins=[MyPlugin])
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -4,10 +4,11 @@ import contextlib
 # Local library
 from . import lib
 
-from pyblish import api, logic, plugin
+from pyblish import api, logic, plugin, util
 
 from nose.tools import (
-    with_setup
+    with_setup,
+    assert_equals,
 )
 
 
@@ -75,3 +76,69 @@ def test_register_gui():
 
         print(logic.registered_guis())
         assert logic.registered_guis() == ["first", "second", "third"]
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_subset_match():
+    """Plugin.match = api.Subset works as expected"""
+
+    count = {"#": 0}
+
+    class MyPlugin(api.InstancePlugin):
+        families = ["a", "b"]
+        match = api.Subset
+
+        def process(self, instance):
+            count["#"] += 1
+
+    context = api.Context()
+
+    context.create_instance("not_included_1", families=["a"])
+    context.create_instance("not_included_1", families=["x"])
+    context.create_instance("included_1", families=["a", "b"])
+    context.create_instance("included_2", families=["a", "b", "c"])
+
+    util.publish(context, plugins=[MyPlugin])
+
+    assert_equals(count["#"], 2)
+
+    instances = logic.instances_by_plugin(context, MyPlugin)
+    assert_equals(list(i.name for i in instances), ["included_1", "included_2"])
+
+
+def test_subset_exact():
+    """Plugin.match = api.Exact works as expected
+
+    Notice the 'default' family in the plug-in. Instances are automatically
+    imbued with this family on creation, as value to their `data["family"]` key.
+
+    When using multiple families, it is common not to bother modifying `family`,
+    and in the future this member needn't be there at all and may/should be
+    removed. But till then, for complete clarity, it might be worth removing this
+    explicitly during the creation of instances if instead choosing to use the
+    `families` key.
+
+    """
+
+    count = {"#": 0}
+
+    class MyPlugin(api.InstancePlugin):
+        families = ["default", "a", "b"]
+        match = api.Exact
+
+        def process(self, instance):
+            count["#"] += 1
+
+    context = api.Context()
+
+    context.create_instance("not_included_1", families=["a"])
+    context.create_instance("not_included_1", families=["x"])
+    context.create_instance("not_included_3", families=["a", "b", "c"])
+    context.create_instance("included_1", families=["a", "b"])
+
+    util.publish(context, plugins=[MyPlugin])
+
+    assert_equals(count["#"], 1)
+
+    instances = logic.instances_by_plugin(context, MyPlugin)
+    assert_equals(list(i.name for i in instances), ["included_1"])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,6 +2,7 @@ import os
 
 from pyblish.vendor import mock
 import pyblish.api
+import pyblish.util
 import pyblish.plugin
 from nose.tools import (
     with_setup,
@@ -712,7 +713,7 @@ def test_argumentless_explitic_plugin():
 
 @with_setup(lib.setup_empty, lib.teardown)
 def test_changes_to_registered_plugins_are_not_persistent():
-    """Changes to registerd plug-ins do not persist
+    """Changes to registered plug-ins do not persist
 
     This is the expected behaviour of file-based plug-ins.
 
@@ -732,3 +733,27 @@ def test_changes_to_registered_plugins_are_not_persistent():
 
     registered = pyblish.api.registered_plugins()[0]
     assert registered.active is False
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_subset_match():
+    """Check plug-ins matching by subset"""
+
+    count = {"#": 0}
+
+    class MyPlugin(pyblish.api.InstancePlugin):
+        families = ["a", "b"]
+        match = pyblish.api.Subset
+
+        def process(self, instance):
+            count["#"] += 1
+
+    context = pyblish.api.Context()
+    context.create_instance("a", families=["a"])
+    context.create_instance("x", families=["x"])
+    context.create_instance("ab", families=["a", "b"])
+    context.create_instance("abc", families=["a", "b", "c"])
+
+    pyblish.util.publish(context, plugins=[MyPlugin])
+
+    assert_equals(count["#"], 2)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -733,27 +733,3 @@ def test_changes_to_registered_plugins_are_not_persistent():
 
     registered = pyblish.api.registered_plugins()[0]
     assert registered.active is False
-
-
-@with_setup(lib.setup_empty, lib.teardown)
-def test_subset_match():
-    """Check plug-ins matching by subset"""
-
-    count = {"#": 0}
-
-    class MyPlugin(pyblish.api.InstancePlugin):
-        families = ["a", "b"]
-        match = pyblish.api.Subset
-
-        def process(self, instance):
-            count["#"] += 1
-
-    context = pyblish.api.Context()
-    context.create_instance("a", families=["a"])
-    context.create_instance("x", families=["x"])
-    context.create_instance("ab", families=["a", "b"])
-    context.create_instance("abc", families=["a", "b", "c"])
-
-    pyblish.util.publish(context, plugins=[MyPlugin])
-
-    assert_equals(count["#"], 2)


### PR DESCRIPTION
This enables the use of multiple families of an instance to be associated with a plug-in, only when said families are a *subset* of the families supported by a plug-in.

That's a mouth full!

**All algorithms**

| Algorithm    | Description
|:--------------|:-----------------
| Intersection| Include instances that match *any* supported family of plug-in (default) 
| Subset         | Include instances that match *all* supported families of a plug-in
| Exact            | Include instances that include *only* supported families of a plug-in

<br>

### Example

Let's see an example.

```python
from pyblish import api

class GenericPlugin(api.InstancePlugin):

  # Support both models and rigs
  families = ["model", "rig"]

  def process(self, instance):
    # Applies to both models and rigs
    assert "parent_GRP" in instance

class SpecificPlugin(api.InstancePlugin):

  # Support models, but only low-poly models
  families = ["model", "low"]
  match = api.Subset

  def process(self, instance):
    # Applies to only low-poly models
    assert instance.data["polyCount"] < 500
```

In this example, `SpecificPlugin` is associated to instances whose family(ies) are a subset of the supported families `model` and `low`. If the instance does not have *at least* both of these, it is not a match.

This is different from `GenericPlugin`, where only one of the families of an instance need to match any of the supported families of a plug-in.

The `match` parameter then is a *matching algorithm*, as provided by standard set functionality.

```python
# 1. Include on any match
assert set(["a", "b"]).intersection(["b", "c"])

# 2. Include on all match
assert set(["a", "b"]).issubset(["a", "b", "c"])

# 3. Include on exact match (note order is independent)
assert set(["a", "b"]) == set(["b", "a"])
```

The default value for this parameter is `api.Intersection` to preserve backwards compatibility. The last possible value is `api.Exact` which means an instance only matches when families of both instance and plug-ins match *exactly*.

```python
class EdgeCasePlugin(api.InstancePlugin):
  families = ["model", "low", "level21"]
  match = api.Exact

  def process(self, instance):
    assert "specialMember" in instance
```

See [`test_logic.py`]() for complete examples.