### PR TITLE
Fix Module mixup with same named files (#306)

### DIFF
--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -157,6 +157,7 @@ def __init__():
     # Register default test
     register_test(__default_test)
 
+
 __init__()
 
 
@@ -165,6 +166,11 @@ __all__ = [
     "Context",
     "Instance",
     "Asset",
+
+    # Matching algorithms
+    "Subset",
+    "Intersection",
+    "Exact",
 
     "Plugin",
     "Action",

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1260,11 +1260,7 @@ def discover(type=None, regex=None, paths=None):
             if not mod_ext == ".py":
                 continue
 
-            # Remove all characters that isn't in a-z, A-Z and 0-9
-            # See #306 for details
-            safe_name = re.sub(r'([^\w])', "_", abspath)
-
-            module = types.ModuleType(safe_name)
+            module = types.ModuleType(mod_name)
             module.__file__ = abspath
 
             try:
@@ -1274,7 +1270,7 @@ def discover(type=None, regex=None, paths=None):
                 # Store reference to original module, to avoid
                 # garbage collection from collecting it's global
                 # imports, such as `import os`.
-                sys.modules[safe_name] = module
+                sys.modules[abspath] = module
 
             except Exception as err:
                 log.debug("Skipped: \"%s\" (%s)", mod_name, err)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1281,6 +1281,7 @@ def discover(type=None, regex=None, paths=None):
                     log.debug("Duplicate plug-in found: %s", plugin)
                     continue
 
+                plugin.__module__ = module.__file__
                 plugins[plugin.__name__] = plugin
 
     # Include plug-ins from registration.

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -158,11 +158,10 @@ def append_logger(plugin):
 
     """
 
-    module = plugin.__module__
     name = plugin.__name__
 
     # Package name appended, for filtering of LogRecord instances
-    logname = "pyblish.%s.%s" % (module, name)
+    logname = "pyblish.%s" % name
     plugin.log = logging.getLogger(logname)
     plugin.log.setLevel(logging.DEBUG)
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -12,6 +12,7 @@ with "validate" and ends with ".py"
 
 # Standard library
 import os
+import re
 import sys
 import time
 import types
@@ -1260,7 +1261,11 @@ def discover(type=None, regex=None, paths=None):
             if not mod_ext == ".py":
                 continue
 
-            module = types.ModuleType(mod_name)
+            # Remove all characters that isn't in a-z, A-Z and 0-9
+            # See #306 for details
+            safe_name = re.sub(r'([^\w])', "_", abspath)
+
+            module = types.ModuleType(safe_name)
             module.__file__ = abspath
 
             try:
@@ -1270,7 +1275,7 @@ def discover(type=None, regex=None, paths=None):
                 # Store reference to original module, to avoid
                 # garbage collection from collecting it's global
                 # imports, such as `import os`.
-                sys.modules[mod_name] = module
+                sys.modules[safe_name] = module
 
             except Exception as err:
                 log.debug("Skipped: \"%s\" (%s)", mod_name, err)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -12,7 +12,6 @@ with "validate" and ends with ".py"
 
 # Standard library
 import os
-import re
 import sys
 import time
 import types
@@ -424,17 +423,17 @@ def logger(handler):
 
     """
 
-    l = logging.getLogger()
-    old_level = l.level
+    logger = logging.getLogger()
+    old_level = logger.level
 
-    l.addHandler(handler)
-    l.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
 
     try:
         yield
     finally:
-        l.removeHandler(handler)
-        l.setLevel(old_level)
+        logger.removeHandler(handler)
+        logger.setLevel(old_level)
 
 
 def process(plugin, context, instance=None, action=None):
@@ -724,7 +723,7 @@ class Context(AbstractEntity):
 
         try:
             key = key.id
-        except:
+        except Exception:
             pass
 
         return key in [c.id for c in self]
@@ -815,7 +814,7 @@ class Instance(AbstractEntity):
         while parent.parent:
             try:
                 parent = parent.parent
-            except:
+            except Exception:
                 break
 
         assert isinstance(parent, Context), ("Parent was not a Context:"

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 5
-VERSION_PATCH = 2
+VERSION_PATCH = 3
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This alters the name of plug-ins used in-memory to one that is *almost* guaranteed to be unique.

Edge cases include directories with similar characters in similar places.

```bash
c:\my\plögins\collect.py
c:\my\plågins\collect.py
```

Though different, would both result in..

```bash
c__my_pl_gins_collect_py
c__my_pl_gins_collect_py
```

Where the latter one overwrites the former.