### PR TITLE
Revise default target

### DIFF
--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -98,6 +98,7 @@ from .logic import (
     plugins_by_family,
     plugins_by_host,
     plugins_by_instance,
+    plugins_by_targets,
     instances_by_plugin,
     register_test,
     deregister_test,

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -254,10 +254,6 @@ def plugins_by_targets(plugins, targets):
 
     for plugin in plugins:
 
-        if "*" in plugin.targets:
-            compatible.append(plugin)
-            continue
-
         algorithm = _algorithms.get(plugin.match)
 
         assert algorithm, ("Plug-in did not provide "
@@ -358,7 +354,8 @@ def Iterator(plugins, context, state=None):
         "ordersWithError": set()
     }
 
-    plugins = plugins_by_targets(plugins, registered_targets())
+    targets = registered_targets() + ["default"]
+    plugins = plugins_by_targets(plugins, targets)
 
     for plugin in plugins:
         if not plugin.active:

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -227,7 +227,7 @@ class Plugin():
 
     hosts = ["*"]
     families = ["*"]
-    targets = ["*"]
+    targets = ["default"]
     label = None
     active = True
     version = (0, 0, 0)

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -31,6 +31,7 @@ def setup_empty():
     pyblish.plugin.deregister_all_paths()
     pyblish.plugin.deregister_all_hosts()
     pyblish.plugin.deregister_all_callbacks()
+    pyblish.plugin.deregister_all_targets()
 
 
 def teardown():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -754,13 +754,13 @@ def test_logging_solely_from_pyblish():
 
 @with_setup(lib.setup_empty, lib.teardown)
 def test_running_for_all_targets():
-    """Run for all targets when family is "*"."""
+    """Run for all targets when family is "default"."""
 
     count = {"#": 0}
 
     class plugin(pyblish.api.ContextPlugin):
 
-        targets = ["*"]
+        targets = ["default"]
 
         def process(self, context):
             count["#"] += 1

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -812,3 +812,43 @@ def test_only_run_plugins_that_match_registered_targets():
     pyblish.util.publish(plugins=[pluginStudio, pluginProject])
 
     assert count["#"] == 1, "count is {0}".format(count)
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_targets_and_exact_matching():
+    """Run targets with exact matching."""
+
+    count = {"#": 0}
+
+    class pluginStudio(pyblish.api.ContextPlugin):
+
+        targets = ["default", "studio"]
+        match = pyblish.api.Exact
+
+        def process(self, context):
+            count["#"] += 1
+
+    pyblish.api.register_target("studio")
+    pyblish.util.publish(plugins=[pluginStudio])
+
+    assert count["#"] == 1, "count is {0}".format(count)
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_targets_and_subset_matching():
+    """Run targets with subset matching."""
+
+    count = {"#": 0}
+
+    class pluginStudio(pyblish.api.ContextPlugin):
+
+        targets = ["studio"]
+        match = pyblish.api.Subset
+
+        def process(self, context):
+            count["#"] += 1
+
+    pyblish.api.register_target("studio")
+    pyblish.util.publish(plugins=[pluginStudio])
+
+    assert count["#"] == 1, "count is {0}".format(count)


### PR DESCRIPTION
**Motivation**

The default target for plugins of ```*``` was confusing when dealing with logic that exclusively targeted plugins.
Further the ```plugins_by_targets``` has been revised to not assume a wildcard target to facilitate using the method outside of pyblish-base. This method is now exposed in the ```pyblish.api``` as well.
For these reasons the default target has been changed to ```default```.