### PR TITLE
Explicit target default plugins.

### DIFF
--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -354,12 +354,9 @@ def Iterator(plugins, context, state=None):
         "ordersWithError": set()
     }
 
-    targets = registered_targets()
-
     # We'll add "default" target if no targets are registered. This happens
     # when running the Iterator directly without registering any targets.
-    if not targets:
-        targets = ["default"]
+    targets = registered_targets() or ["default"]
 
     plugins = plugins_by_targets(plugins, targets)
 

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -354,7 +354,13 @@ def Iterator(plugins, context, state=None):
         "ordersWithError": set()
     }
 
-    targets = registered_targets() + ["default"]
+    targets = registered_targets()
+
+    # We'll add "default" target if no targets are registered. This happens
+    # when running the Iterator directly without registering any targets.
+    if not targets:
+        targets = ["default"]
+
     plugins = plugins_by_targets(plugins, targets)
 
     for plugin in plugins:

--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -12,7 +12,7 @@ from . import api, logic, plugin, lib
 log = logging.getLogger("pyblish.util")
 
 
-def publish(context=None, plugins=None, targets=["default"]):
+def publish(context=None, plugins=None, targets=None):
     """Publish everything
 
     This function will process all available plugins of the
@@ -32,6 +32,10 @@ def publish(context=None, plugins=None, targets=["default"]):
         >> context = publish()  # ..or receive a new
 
     """
+
+    # Include "default" target when no targets are requested.
+    if targets is None:
+        targets = ["default"]
 
     # Must check against None, as objects be emptys
     context = api.Context() if context is None else context

--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -12,7 +12,7 @@ from . import api, logic, plugin, lib
 log = logging.getLogger("pyblish.util")
 
 
-def publish(context=None, plugins=None, targets=[]):
+def publish(context=None, plugins=None, targets=["default"]):
     """Publish everything
 
     This function will process all available plugins of the
@@ -103,7 +103,7 @@ def publish(context=None, plugins=None, targets=[]):
     return context
 
 
-def collect(context=None, plugins=None, targets=[]):
+def collect(context=None, plugins=None, targets=["default"]):
     """Convenience function for collection-only
 
      _________    . . . . .  .   . . . . . .   . . . . . . .
@@ -118,7 +118,7 @@ def collect(context=None, plugins=None, targets=[]):
     return context
 
 
-def validate(context=None, plugins=None, targets=[]):
+def validate(context=None, plugins=None, targets=["default"]):
     """Convenience function for validation-only
 
     . . . . . .    __________    . . . . . .   . . . . . . .
@@ -133,7 +133,7 @@ def validate(context=None, plugins=None, targets=[]):
     return context
 
 
-def extract(context=None, plugins=None, targets=[]):
+def extract(context=None, plugins=None, targets=["default"]):
     """Convenience function for extraction-only
 
     . . . . . .   . . . . .  .    _________    . . . . . . .
@@ -148,7 +148,7 @@ def extract(context=None, plugins=None, targets=[]):
     return context
 
 
-def integrate(context=None, plugins=None, targets=[]):
+def integrate(context=None, plugins=None, targets=["default"]):
     """Convenience function for integration-only
 
     . . . . . .   . . . . .  .   . . . . . .    ___________
@@ -163,7 +163,7 @@ def integrate(context=None, plugins=None, targets=[]):
     return context
 
 
-def _convenience(order, context=None, plugins=None, targets=[]):
+def _convenience(order, context=None, plugins=None, targets=["default"]):
     plugins = list(
         p for p in (api.discover() if plugins is None else plugins)
         if lib.inrange(p.order, order)

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 5
-VERSION_PATCH = 3
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -856,7 +856,7 @@ def test_targets_and_subset_matching():
 
 @with_setup(lib.setup_empty, lib.teardown)
 def test_targets_and_publishing():
-    """Ony run plugins with requested targets."""
+    """Only run plugins with requested targets."""
 
     count = {"#": 0}
 
@@ -879,7 +879,7 @@ def test_targets_and_publishing():
 
 @with_setup(lib.setup_empty, lib.teardown)
 def test_targets_and_publishing_with_default():
-    """Ony run plugins with requested targets including default."""
+    """Only run plugins with requested targets including default."""
 
     count = {"#": 0}
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -852,3 +852,29 @@ def test_targets_and_subset_matching():
     pyblish.util.publish(plugins=[pluginStudio])
 
     assert count["#"] == 1, "count is {0}".format(count)
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_targets_and_publishing():
+    """Ony run plugins with requested targets."""
+
+    count = {"#": 0}
+
+    class collectA(pyblish.api.ContextPlugin):
+
+        order = pyblish.api.CollectorOrder
+        targets = ["customA"]
+
+        def process(self, context):
+            count["#"] += 1
+
+    class collectB(pyblish.api.ContextPlugin):
+
+        order = pyblish.api.CollectorOrder
+
+        def process(self, context):
+            count["#"] += 1
+
+    pyblish.util.publish(plugins=[collectA, collectB], targets=["customA"])
+
+    assert count["#"] == 1, "count is {0}".format(count)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -860,21 +860,43 @@ def test_targets_and_publishing():
 
     count = {"#": 0}
 
-    class collectA(pyblish.api.ContextPlugin):
+    class pluginA(pyblish.api.ContextPlugin):
 
-        order = pyblish.api.CollectorOrder
         targets = ["customA"]
 
         def process(self, context):
             count["#"] += 1
 
-    class collectB(pyblish.api.ContextPlugin):
-
-        order = pyblish.api.CollectorOrder
+    class pluginB(pyblish.api.ContextPlugin):
 
         def process(self, context):
             count["#"] += 1
 
-    pyblish.util.publish(plugins=[collectA, collectB], targets=["customA"])
+    pyblish.util.publish(plugins=[pluginA, pluginB], targets=["customA"])
 
     assert count["#"] == 1, "count is {0}".format(count)
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_targets_and_publishing_with_default():
+    """Ony run plugins with requested targets including default."""
+
+    count = {"#": 0}
+
+    class pluginA(pyblish.api.ContextPlugin):
+
+        targets = ["customA"]
+
+        def process(self, context):
+            count["#"] += 1
+
+    class pluginB(pyblish.api.ContextPlugin):
+
+        def process(self, context):
+            count["#"] += 1
+
+    pyblish.util.publish(
+        plugins=[pluginA, pluginB], targets=["default", "customA"]
+    )
+
+    assert count["#"] == 2, "count is {0}".format(count)


### PR DESCRIPTION
**Motivation**

Only include default plugins when explicitly requesting so.

The problem case is when you have default targeted collectors that produce instances, with plugins targeted to "default".