### PR TITLE
Implement #250

### DIFF
--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -348,6 +348,12 @@ def Iterator(plugins, context, state=None):
 
     """
 
+    # Run ContextPlugin only if instance of family is present when not "*"
+    # This is to preserve backwards compatility.
+    PYBLISH_CONTEXTPLUGIN_ON_FAMILY = bool(
+        os.getenv("PYBLISH_CONTEXTPLUGIN_ON_FAMILY")
+    )
+
     test = registered_test()
     state = state or {
         "nextOrder": None,
@@ -381,12 +387,13 @@ def Iterator(plugins, context, state=None):
                 yield plugin, instance
 
         else:
-        
-            # When filtering to families at least a single instance with
-            # that family must be active in the current publish
-            if "*" not in plugin.families:
-                if not any(instance.data.get("publish") is not False 
-                           for instance in instances):
-                    continue
-                    
+
+            if PYBLISH_CONTEXTPLUGIN_ON_FAMILY:
+                # When filtering to families at least a single instance with
+                # that family must be active in the current publish
+                if "*" not in plugin.families:
+                    if not any(instance.data.get("publish") is not False
+                               for instance in instances):
+                        continue
+
             yield plugin, None

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -381,4 +381,12 @@ def Iterator(plugins, context, state=None):
                 yield plugin, instance
 
         else:
+        
+            # When filtering to families at least a single instance with
+            # that family must be active in the current publish
+            if "*" not in plugin.families:
+                if not any(instance.data.get("publish") is not False 
+                           for instance in instances):
+                    continue
+                    
             yield plugin, None

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -76,3 +76,18 @@ def tempdir():
         yield tempdir
     finally:
         shutil.rmtree(tempdir)
+
+
+@contextlib.contextmanager
+def env_override(overrides):
+    """Temporarily override environment variables"""
+    assert isinstance(overrides, dict)
+    original = os.environ.copy()
+    os.environ.update(overrides)
+
+    try:
+        yield
+    finally:
+        # Reset
+        os.environ.clear()
+        os.environ.update(original)


### PR DESCRIPTION
This implements #250 where ContextPlugins that filter to specific families (so `"*" not in plugin.families`) will *not* run when no instance present that the given family.

When the ContextPlugin filters to two families and both are present by instances the ContextPlugin will still only run once.

```python
import pyblish.api

class Collector(pyblish.api.ContextPlugin):
    order = pyblish.api.CollectorOrder
    
    def process(self, context):
        instance = context.create_instance("a1")
        instance.data['families'] = ["a"]
        
        
        instance = context.create_instance("a2")
        instance.data['families'] = ["a"]
        
        
        instance = context.create_instance("c1")
        instance.data['families'] = ["c"]
        
        
class ValidateA(pyblish.api.ContextPlugin):
    families = ["a"]
    order = pyblish.api.CollectorOrder
    
    def process(self, context):
        print("Processing %s" % self.__class__.__name__)
        
     
class ValidateB(pyblish.api.ContextPlugin):
    families = ["b"]
    order = pyblish.api.CollectorOrder
    
    def process(self, context):
        print("Processing %s" % self.__class__.__name__)
        
     
class ValidateAC(pyblish.api.ContextPlugin):
    families = ["a", "c"]
    order = pyblish.api.CollectorOrder
    
    def process(self, context):
        print("Processing %s" % self.__class__.__name__)
        
        
class ValidateAlways(pyblish.api.ContextPlugin):
    order = pyblish.api.CollectorOrder
    
    def process(self, context):
        print("Processing %s" % self.__class__.__name__)
        


pyblish.plugin.deregister_all_plugins()
pyblish.plugin.deregister_all_paths()
pyblish.plugin.deregister_all_hosts()
pyblish.plugin.deregister_all_callbacks()
pyblish.plugin.deregister_all_targets()
pyblish.api.register_plugin(Collector)
pyblish.api.register_plugin(ValidateA)
pyblish.api.register_plugin(ValidateB)
pyblish.api.register_plugin(ValidateAC)
pyblish.api.register_plugin(ValidateAlways)
pyblish.util.publish()

# Processing ValidateAC
# Processing ValidateA
# Processing ValidateAlways
```