### PR TITLE
Check whether any registered guis override default

### DIFF
--- a/pyblish/cli.py
+++ b/pyblish/cli.py
@@ -342,7 +342,13 @@ def gui(ctx, package):
     environ = os.environ.copy()
     context = ctx.obj["context"]
 
+    registered_guis = api.registered_guis()
+
     with _cli_plugin(data=context.data) as plugin_path:
+
+        if len(registered_guis) > 0:
+            package = registered_guis[0]
+
         environ["PYBLISHPLUGINPATH"] = os.pathsep.join(
             ctx.obj["plugin_paths"] + [plugin_path]
         )

--- a/pyblish/cli.py
+++ b/pyblish/cli.py
@@ -344,10 +344,10 @@ def gui(ctx, package):
 
     registered_guis = api.registered_guis()
 
-    with _cli_plugin(data=context.data) as plugin_path:
+    if len(registered_guis) > 0:
+        package = registered_guis[0]
 
-        if len(registered_guis) > 0:
-            package = registered_guis[0]
+    with _cli_plugin(data=context.data) as plugin_path:
 
         environ["PYBLISHPLUGINPATH"] = os.pathsep.join(
             ctx.obj["plugin_paths"] + [plugin_path]

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 5
-VERSION_PATCH = 4
+VERSION_PATCH = 5
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,41 @@ if __name__ == '__main__':
 
 
 @with_setup(lib.setup, lib.teardown)
+def test_uses_gui_from_env():
+    """Uses gui from environment var works"""
+
+    with tempfile.NamedTemporaryFile(dir=self.tempdir,
+                                     delete=False,
+                                     suffix=".py") as f:
+        module_name = os.path.basename(f.name)[:-3]
+        f.write(b"""\
+def show():
+    print("Mock GUI shown successfully")
+
+if __name__ == '__main__':
+    show()
+""")
+
+    pythonpath = os.pathsep.join([
+        self.tempdir,
+        os.environ.get("PYTHONPATH", "")
+    ])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pyblish.cli.main, ["gui"],
+        env={
+            "PYTHONPATH": pythonpath,
+            "PYBLISH_GUI": module_name
+        }
+    )
+
+    assert_equals(result.output.splitlines()[-1].rstrip(),
+                  "Mock GUI shown successfully")
+    assert_equals(result.exit_code, 0)
+
+
+@with_setup(lib.setup, lib.teardown)
 def test_passing_data_to_gui():
     """Passing data to GUI works"""
 


### PR DESCRIPTION
**Motivation**

Allow the cli to use registered guis set by PYBLISH_GUI. Currently when the environment var has been set, pyblish still needs to be called supplying it as an argument.

**Changes**

This change looks for any registered guis before falling back to the default package argument.