### PR TITLE
plugin path normalize

### DIFF
--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -152,7 +152,7 @@ def __init__():
             register_host(host)
 
     # Register default path
-    register_plugin_path("%s/plugins" % __main_package_path())
+    register_plugin_path(os.path.join(__main_package_path(), "plugins"))
 
     # Register default test
     register_test(__default_test)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1008,10 +1008,12 @@ def register_plugin_path(path):
     Example:
         >>> import os
         >>> # Linux
-        >>> register_plugin_path("server/pluginsA") == os.path.join("server", "pluginsA")
+        >>> plugins_A = "server/pluginsA"
+        >>> register_plugin_path(plugins_A) == os.path.normpath(plugins_A)
         True
         >>> # Windows
-        >>> register_plugin_path(r"server\pluginsB") == os.path.join("server", "pluginsB")
+        >>> plugins_B = r"server\pluginsB"
+        >>> register_plugin_path(plugins_B) == os.path.normpath(plugins_B)
         True
         >>> deregister_plugin_path("server/pluginsA")
         >>> deregister_plugin_path("server/pluginsB")

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1016,6 +1016,7 @@ def register_plugin_path(path):
 
     """
 
+    path = os.path.normpath(path)
     if path in _registered_paths:
         return log.warning("Path already registered: {0}".format(path))
 
@@ -1032,6 +1033,7 @@ def deregister_plugin_path(path):
 
     """
 
+    path = os.path.normpath(path)
     _registered_paths.remove(path)
 
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1009,14 +1009,13 @@ def register_plugin_path(path):
         >>> import os
         >>> my_plugins = "/server/plugins"
         >>> register_plugin_path(my_plugins)
-        '\\\\server\\\\plugins'
+        '/server/plugins'
 
     Returns:
         Actual path added, including any post-processing
 
     """
 
-    path = os.path.normpath(path)
     if path in _registered_paths:
         return log.warning("Path already registered: {0}".format(path))
 
@@ -1028,13 +1027,14 @@ def register_plugin_path(path):
 def deregister_plugin_path(path):
     """Remove a pyblish._registered_paths path
 
-    Raises:
-        KeyError if `path` isn't registered
+    .. note:: Log warning if `path` isn't registered
 
     """
 
-    path = os.path.normpath(path)
-    _registered_paths.remove(path)
+    try:
+        _registered_paths.remove(path)
+    except ValueError:
+        return log.warning("Path not in registered list: {0}".format(path))
 
 
 def deregister_all_paths():

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1007,9 +1007,11 @@ def register_plugin_path(path):
 
     Example:
         >>> import os
-        >>> my_plugins = "server/plugins"
-        >>> register_plugin_path(my_plugins) == os.path.join("server", "plugins")
+        >>> # Linux
+        >>> register_plugin_path("server/plugins") == os.path.join("server", "plugins")
         True
+        >>> # Windows
+        >>> register_plugin_path(r"server\plugins") == os.path.join("server", "plugins")
 
     Returns:
         Actual path added, including any post-processing

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1008,10 +1008,10 @@ def register_plugin_path(path):
     Example:
         >>> import os
         >>> # Linux
-        >>> register_plugin_path("server/pluginsA") == os.path.join("server", "plugins")
+        >>> register_plugin_path("server/pluginsA") == os.path.join("server", "pluginsA")
         True
         >>> # Windows
-        >>> register_plugin_path(r"server\pluginsB") == os.path.join("server", "plugins")
+        >>> register_plugin_path(r"server\pluginsB") == os.path.join("server", "pluginsB")
         True
         >>> deregister_plugin_path("server/pluginsA")
         >>> deregister_plugin_path("server/pluginsB")

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1009,7 +1009,7 @@ def register_plugin_path(path):
         >>> import os
         >>> my_plugins = "/server/plugins"
         >>> register_plugin_path(my_plugins)
-        '/server/plugins'
+        '\\server\\plugins'
 
     Returns:
         Actual path added, including any post-processing

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1008,11 +1008,13 @@ def register_plugin_path(path):
     Example:
         >>> import os
         >>> # Linux
-        >>> register_plugin_path("server/plugins") == os.path.join("server", "plugins")
+        >>> register_plugin_path("server/pluginsA") == os.path.join("server", "plugins")
         True
         >>> # Windows
-        >>> register_plugin_path(r"server\plugins") == os.path.join("server", "plugins")
+        >>> register_plugin_path(r"server\pluginsB") == os.path.join("server", "plugins")
         True
+        >>> deregister_plugin_path("server/pluginsA")
+        >>> deregister_plugin_path("server/pluginsB")
 
     Returns:
         Actual path added, including any post-processing

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1009,7 +1009,7 @@ def register_plugin_path(path):
         >>> import os
         >>> my_plugins = "/server/plugins"
         >>> register_plugin_path(my_plugins)
-        '\\server\\plugins'
+        '\\\\server\\\\plugins'
 
     Returns:
         Actual path added, including any post-processing

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1012,6 +1012,7 @@ def register_plugin_path(path):
         True
         >>> # Windows
         >>> register_plugin_path(r"server\plugins") == os.path.join("server", "plugins")
+        True
 
     Returns:
         Actual path added, including any post-processing
@@ -1019,6 +1020,7 @@ def register_plugin_path(path):
     """
 
     path = os.path.normpath(path)
+
     if path in _registered_paths:
         return log.warning("Path already registered: {0}".format(path))
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1007,9 +1007,9 @@ def register_plugin_path(path):
 
     Example:
         >>> import os
-        >>> my_plugins = "/server/plugins"
-        >>> register_plugin_path(my_plugins)
-        '\\\\server\\\\plugins'
+        >>> my_plugins = "server/plugins"
+        >>> register_plugin_path(my_plugins) == os.path.join("server", "plugins")
+        True
 
     Returns:
         Actual path added, including any post-processing

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1015,8 +1015,8 @@ def register_plugin_path(path):
         >>> plugins_B = r"server\pluginsB"
         >>> register_plugin_path(plugins_B) == os.path.normpath(plugins_B)
         True
-        >>> deregister_plugin_path("server/pluginsA")
-        >>> deregister_plugin_path("server/pluginsB")
+        >>> deregister_plugin_path(plugins_A)
+        >>> deregister_plugin_path(plugins_B)
 
     Returns:
         Actual path added, including any post-processing

--- a/tests/pre11/test_plugins.py
+++ b/tests/pre11/test_plugins.py
@@ -65,9 +65,9 @@ def test_entities_prints_nicely():
 def test_deregister_path():
     path = "/server/plugins"
     pyblish.plugin.register_plugin_path(path)
-    assert os.path.normpath(path) in pyblish.plugin.registered_paths()
+    assert path in pyblish.plugin.registered_paths()
     pyblish.plugin.deregister_plugin_path(path)
-    assert os.path.normpath(path) not in pyblish.plugin.registered_paths()
+    assert path not in pyblish.plugin.registered_paths()
 
 
 def test_environment_paths():

--- a/tests/pre11/test_plugins.py
+++ b/tests/pre11/test_plugins.py
@@ -65,9 +65,9 @@ def test_entities_prints_nicely():
 def test_deregister_path():
     path = "/server/plugins"
     pyblish.plugin.register_plugin_path(path)
-    assert path in pyblish.plugin.registered_paths()
+    assert os.path.normpath(path) in pyblish.plugin.registered_paths()
     pyblish.plugin.deregister_plugin_path(path)
-    assert path not in pyblish.plugin.registered_paths()
+    assert os.path.normpath(path) not in pyblish.plugin.registered_paths()
 
 
 def test_environment_paths():


### PR DESCRIPTION
Two simple improvement as follow :
1. use `os.path.join` instead of hard-coded slash to compose default plugin path.
2. use `os.path.normpath` to normalize plugin path before register/deregister it.