### PR TITLE
use os.path.join to compose default plugin path

### DIFF
--- a/pyblish/api.py
+++ b/pyblish/api.py
@@ -152,7 +152,7 @@ def __init__():
             register_host(host)
 
     # Register default path
-    register_plugin_path("%s/plugins" % __main_package_path())
+    register_plugin_path(os.path.join(__main_package_path(), "plugins"))
 
     # Register default test
     register_test(__default_test)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1007,19 +1007,20 @@ def register_plugin_path(path):
 
     Example:
         >>> import os
-        >>> my_plugins = "/server/plugins"
-        >>> register_plugin_path(my_plugins)
-        '/server/plugins'
+        >>> my_plugins = os.path.join("server", "plugins")
+        >>> register_plugin_path(my_plugins) == os.path.normpath(my_plugins)
+        True
 
     Returns:
         Actual path added, including any post-processing
 
     """
 
-    if path in _registered_paths:
+    normpath = os.path.normpath(path)
+    if normpath in _registered_paths:
         return log.warning("Path already registered: {0}".format(path))
 
-    _registered_paths.append(path)
+    _registered_paths.append(normpath)
 
     return path
 
@@ -1028,11 +1029,15 @@ def deregister_plugin_path(path):
     """Remove a pyblish._registered_paths path
 
     Raises:
-        KeyError if `path` isn't registered
+        ValueError if `path` isn't registered
 
     """
 
-    _registered_paths.remove(path)
+    normpath = os.path.normpath(path)
+    try:
+        _registered_paths.remove(normpath)
+    except ValueError:
+        return log.error("Path isn't registered: {0}".format(path))
 
 
 def deregister_all_paths():

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 5
-VERSION_PATCH = 5
+VERSION_PATCH = 6
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/pre11/test_plugins.py
+++ b/tests/pre11/test_plugins.py
@@ -65,9 +65,9 @@ def test_entities_prints_nicely():
 def test_deregister_path():
     path = "/server/plugins"
     pyblish.plugin.register_plugin_path(path)
-    assert path in pyblish.plugin.registered_paths()
+    assert os.path.normpath(path) in pyblish.plugin.registered_paths()
     pyblish.plugin.deregister_plugin_path(path)
-    assert path not in pyblish.plugin.registered_paths()
+    assert os.path.normpath(path) not in pyblish.plugin.registered_paths()
 
 
 def test_environment_paths():


### PR DESCRIPTION
Change to `os.path.join` for cross-platform.