### PR TITLE
make Instance able to return all families, for convenience

### DIFF
--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -209,8 +209,7 @@ def plugins_by_instance(plugins, instance):
 
     """
 
-    return plugins_by_families(
-        plugins, instance.families)
+    return plugins_by_families(plugins, instance.families)
 
 
 def plugins_by_host(plugins, host):

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -209,11 +209,8 @@ def plugins_by_instance(plugins, instance):
 
     """
 
-    family = instance.data.get("family")
-    families = instance.data.get("families", [])
-
     return plugins_by_families(
-        plugins, ([family] if family else []) + families)
+        plugins, instance.families)
 
 
 def plugins_by_host(plugins, host):
@@ -299,11 +296,7 @@ def instances_by_plugin(instances, plugin):
         assert algorithm, ("Plug-in did not provide "
                            "valid matching algorithm: %s" % plugin.match)
 
-        family = instance.data.get("family")
-        families = [family] if family else []
-        families += instance.data.get("families", [])
-
-        if algorithm(plugin.families, families):
+        if algorithm(plugin.families, instance.families):
             compatible.append(instance)
 
     return compatible

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -319,7 +319,7 @@ def _extract_traceback(exception):
         exc_type, exc_value, exc_traceback = sys.exc_info()
         exception.traceback = traceback.extract_tb(exc_traceback)[-1]
 
-    except:
+    except Exception:
         pass
 
     finally:

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -810,6 +810,15 @@ class Instance(AbstractEntity):
         return self._name
 
     @property
+    def families(self):
+        """Return list of family and families"""
+        family = self._data.get("family")
+        families = [family] if family else []
+        families += self._data.get("families", [])
+
+        return families
+
+    @property
     def context(self):
         """Return top-level parent; the context"""
         parent = self.parent

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -57,6 +57,20 @@ def test_context_from_instance():
     assert_equals(context, instance.context)
 
 
+def test_families_from_instance():
+    """Instances provide access to their families"""
+
+    context = pyblish.plugin.Context()
+    instance = context.create_instance("MyInstance")
+    instance.data["family"] = "A"
+    families = list(instance.data["family"])
+    assert_equals(families, instance.families)
+
+    instance.data["families"] = ["B", "C"]
+    families.extend(instance.data["families"])
+    assert_equals(families, instance.families)
+
+
 def test_legacy():
     """Legacy is determined by existing process_* methods"""
     class LegacyPlugin(pyblish.plugin.Collector):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -63,11 +63,11 @@ def test_families_from_instance():
     context = pyblish.plugin.Context()
     instance = context.create_instance("MyInstance")
     instance.data["family"] = "A"
-    families = list(instance.data["family"])
+    families = [instance.data["family"]]
     assert_equals(families, instance.families)
 
     instance.data["families"] = ["B", "C"]
-    families.extend(instance.data["families"])
+    families += instance.data["families"]
     assert_equals(families, instance.families)
 
 


### PR DESCRIPTION
I think this could provide a bit more convenience.

Instead of querying `family` and `families` from `instance.data` and adding them up every time we need that info, making that as a built-in would be nice, right ?

Happy new year :)