### PR TITLE
Duplicate plugin names should be supported.

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1285,11 +1285,10 @@ def discover(type=None, regex=None, paths=None):
                         "PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES", "False"
                     )
                 )
-                if not allow_duplicates:
-                    if plugin.__name__ in plugin_names:
-                        log.debug("Duplicate plug-in found: %s", plugin)
-                        continue
-                    plugin_names.append(plugin.__name__)
+                if not allow_duplicates and plugin.__name__ in plugin_names:
+                    log.debug("Duplicate plug-in found: %s", plugin)
+                    continue
+                plugin_names.append(plugin.__name__)
 
                 plugin.__module__ = module.__file__
                 key = "{0}.{1}".format(plugin.__module__, plugin.__name__)
@@ -1305,11 +1304,10 @@ def discover(type=None, regex=None, paths=None):
                 "PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES", "False"
             )
         )
-        if not allow_duplicates:
-            if plugin.__name__ in plugin_names:
-                log.debug("Duplicate plug-in found: %s", plugin)
-                continue
-            plugin_names.append(plugin.__name__)
+        if not allow_duplicates and plugin.__name__ in plugin_names:
+            log.debug("Duplicate plug-in found: %s", plugin)
+            continue
+        plugin_names.append(plugin.__name__)
 
         plugins[plugin.__name__] = plugin
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -45,6 +45,12 @@ Intersection = 1 << 0
 Subset = 1 << 1
 Exact = 1 << 2
 
+# Check for duplicate plugin names. This is to preserve
+# backwards compatility.
+PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES = bool(
+    os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
+)
+
 
 class Provider():
     """Dependency provider
@@ -1247,12 +1253,6 @@ def discover(type=None, regex=None, paths=None):
 
     plugins = dict()
     plugin_names = []
-
-    # Check for duplicate plugin names. This is to preserve
-    # backwards compatility.
-    PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES = bool(
-        os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
-    )
 
     # Include plug-ins from registered paths
     for path in paths or plugin_paths():

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -45,12 +45,6 @@ Intersection = 1 << 0
 Subset = 1 << 1
 Exact = 1 << 2
 
-# Check for duplicate plugin names. This is to preserve
-# backwards compatility.
-PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES = bool(
-    os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
-)
-
 
 class Provider():
     """Dependency provider
@@ -1253,6 +1247,12 @@ def discover(type=None, regex=None, paths=None):
 
     plugins = dict()
     plugin_names = []
+
+    # Check for duplicate plugin names. This is to preserve
+    # backwards compatility.
+    PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES = bool(
+        os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
+    )
 
     # Include plug-ins from registered paths
     for path in paths or plugin_paths():

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1277,19 +1277,13 @@ def discover(type=None, regex=None, paths=None):
                 continue
 
             for plugin in plugins_from_module(module):
-                if plugin.__name__ in plugins:
-                    log.debug("Duplicate plug-in found: %s", plugin)
-                    continue
-
                 plugin.__module__ = module.__file__
-                plugins[plugin.__name__] = plugin
+                key = "{0}.{1}".format(plugin.__module__, plugin.__name__)
+                plugins[key] = plugin
 
     # Include plug-ins from registration.
     # Directly registered plug-ins take precedence.
     for plugin in registered_plugins():
-        if plugin.__name__ in plugins:
-            log.debug("Duplicate plug-in found: %s", plugin)
-            continue
         plugins[plugin.__name__] = plugin
 
     plugins = list(plugins.values())

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -45,6 +45,12 @@ Intersection = 1 << 0
 Subset = 1 << 1
 Exact = 1 << 2
 
+# Check for duplicate plugin names. This is to preserve
+# backwards compatility.
+PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES = bool(
+    os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
+)
+
 
 class Provider():
     """Dependency provider
@@ -1285,12 +1291,8 @@ def discover(type=None, regex=None, paths=None):
                 continue
 
             for plugin in plugins_from_module(module):
-                # Check for duplicate plugin names. This is to preserve
-                # backwards compatility.
-                allow_duplicates = bool(
-                    os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
-                )
-                if not allow_duplicates and plugin.__name__ in plugin_names:
+                if (not PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES and
+                   plugin.__name__ in plugin_names):
                     log.debug("Duplicate plug-in found: %s", plugin)
                     continue
                 plugin_names.append(plugin.__name__)
@@ -1302,12 +1304,8 @@ def discover(type=None, regex=None, paths=None):
     # Include plug-ins from registration.
     # Directly registered plug-ins take precedence.
     for plugin in registered_plugins():
-        # Check for duplicate plugin names. This is to preserve
-        # backwards compatility.
-        allow_duplicates = bool(
-            os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
-        )
-        if not allow_duplicates and plugin.__name__ in plugin_names:
+        if (not PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES and
+           plugin.__name__ in plugin_names):
             log.debug("Duplicate plug-in found: %s", plugin)
             continue
         plugin_names.append(plugin.__name__)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1304,7 +1304,7 @@ def discover(type=None, regex=None, paths=None):
     # Include plug-ins from registration.
     # Directly registered plug-ins take precedence.
     for plugin in registered_plugins():
-        if not ALLOW_DUPLICATES and plugin.__name__ in plugin_names):
+        if not ALLOW_DUPLICATES and plugin.__name__ in plugin_names:
             log.debug("Duplicate plug-in found: %s", plugin)
             continue
 

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1280,10 +1280,8 @@ def discover(type=None, regex=None, paths=None):
             for plugin in plugins_from_module(module):
                 # Check for duplicate plugin names. This is to preserve
                 # backwards compatility.
-                allow_duplicates = eval(
-                    os.environ.get(
-                        "PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES", "False"
-                    )
+                allow_duplicates = bool(
+                    os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
                 )
                 if not allow_duplicates and plugin.__name__ in plugin_names:
                     log.debug("Duplicate plug-in found: %s", plugin)
@@ -1299,10 +1297,8 @@ def discover(type=None, regex=None, paths=None):
     for plugin in registered_plugins():
         # Check for duplicate plugin names. This is to preserve
         # backwards compatility.
-        allow_duplicates = eval(
-            os.environ.get(
-                "PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES", "False"
-            )
+        allow_duplicates = bool(
+            os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
         )
         if not allow_duplicates and plugin.__name__ in plugin_names:
             log.debug("Duplicate plug-in found: %s", plugin)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -47,7 +47,7 @@ Exact = 1 << 2
 
 # Check for duplicate plugin names. This is to preserve
 # backwards compatility.
-PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES = bool(
+ALLOW_DUPLICATES = bool(
     os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES")
 )
 
@@ -1291,10 +1291,10 @@ def discover(type=None, regex=None, paths=None):
                 continue
 
             for plugin in plugins_from_module(module):
-                if (not PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES and
-                   plugin.__name__ in plugin_names):
+                if not ALLOW_DUPLICATES and plugin.__name__ in plugin_names:
                     log.debug("Duplicate plug-in found: %s", plugin)
                     continue
+
                 plugin_names.append(plugin.__name__)
 
                 plugin.__module__ = module.__file__
@@ -1304,10 +1304,10 @@ def discover(type=None, regex=None, paths=None):
     # Include plug-ins from registration.
     # Directly registered plug-ins take precedence.
     for plugin in registered_plugins():
-        if (not PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES and
-           plugin.__name__ in plugin_names):
+        if not ALLOW_DUPLICATES and plugin.__name__ in plugin_names):
             log.debug("Duplicate plug-in found: %s", plugin)
             continue
+
         plugin_names.append(plugin.__name__)
 
         plugins[plugin.__name__] = plugin

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
-VERSION_MINOR = 5
-VERSION_PATCH = 6
+VERSION_MINOR = 6
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 5
-VERSION_PATCH = 5
+VERSION_PATCH = 6
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -910,23 +910,17 @@ def test_duplicate_plugin_names():
 
     plugins = []
     with lib.tempdir() as temp:
-        plugin = """from pyblish import api
-class collectorA(api.ContextPlugin):
-    def process(self, context):
-        pass
-    """
+        plugin = (
+            "from pyblish import api\nclass collectorA(api.ContextPlugin):"
+            "\n    def process(self, context):\n        pass"
+        )
         path = os.path.join(temp, "pluginA.py")
         with open(path, "w") as the_file:
             the_file.write(plugin)
 
-        plugin_copy = """from pyblish import api
-class collectorA(api.InstancePlugin):
-    def process(self, context):
-        pass
-    """
         path = os.path.join(temp, "pluginA_copy.py")
         with open(path, "w") as the_file:
-            the_file.write(plugin_copy)
+            the_file.write(plugin)
 
         plugins.extend(pyblish.api.discover(paths=[temp]))
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -907,7 +907,7 @@ def test_targets_and_publishing_with_default():
 def test_duplicate_plugin_names():
     logging.basicConfig(level=logging.DEBUG)
 
-    os.environ["PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES"] = "True"
+    pyblish.plugin.PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES = True
 
     plugins = []
     with lib.tempdir() as temp:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import tempfile
 
 from pyblish.vendor import mock
 import pyblish.api

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -908,6 +908,8 @@ def test_targets_and_publishing_with_default():
 def test_duplicate_plugin_names():
     logging.basicConfig(level=logging.DEBUG)
 
+    os.environ["PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES"] = "True"
+
     plugins = []
     with lib.tempdir() as temp:
         plugin = (

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -907,7 +907,7 @@ def test_targets_and_publishing_with_default():
 def test_duplicate_plugin_names():
     logging.basicConfig(level=logging.DEBUG)
 
-    pyblish.plugin.PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES = True
+    pyblish.plugin.ALLOW_DUPLICATES = True
 
     plugins = []
     with lib.tempdir() as temp:
@@ -926,3 +926,9 @@ def test_duplicate_plugin_names():
         plugins.extend(pyblish.api.discover(paths=[temp]))
 
     assert len(plugins) == 2, plugins
+    
+    # Restore state, for subsequent tests
+    # NOTE: This assumes the test succeeds. If it fails, then
+    # subsequent tests can fail because of it.
+    pyblish.plugin.ALLOW_DUPLICATES = True
+

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,6 @@
 import os
+import logging
+import tempfile
 
 from pyblish.vendor import mock
 import pyblish.api
@@ -900,3 +902,32 @@ def test_targets_and_publishing_with_default():
     )
 
     assert count["#"] == 2, "count is {0}".format(count)
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_duplicate_plugin_names():
+    logging.basicConfig(level=logging.DEBUG)
+
+    plugins = []
+    with lib.tempdir() as temp:
+        plugin = """from pyblish import api
+class collectorA(api.ContextPlugin):
+    def process(self, context):
+        pass
+    """
+        path = os.path.join(temp, "pluginA.py")
+        with open(path, "w") as the_file:
+            the_file.write(plugin)
+
+        plugin_copy = """from pyblish import api
+class collectorA(api.InstancePlugin):
+    def process(self, context):
+        pass
+    """
+        path = os.path.join(temp, "pluginA_copy.py")
+        with open(path, "w") as the_file:
+            the_file.write(plugin_copy)
+
+        plugins.extend(pyblish.api.discover(paths=[temp]))
+
+    assert len(plugins) == 2, plugins


### PR DESCRIPTION
This is just the test to show that duplicate plugin names are not supported, so the tests should fail.

I'm pretty sure the issue is [here](https://github.com/pyblish/pyblish-base/blob/master/pyblish/plugin.py#L1287), because we compare the plugin names rather than their class string:
```
<class 'c:\users\tje\appdata\local\temp\tmponhxwt\pluginA.py.collectorA'>
```

What I could not find was where we set this string?