### PR TITLE
Remove Python 2.6 from Travis testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- 2.6
 - 2.7
 - 3.5
 install:


### PR DESCRIPTION
I noticed on the latest release Travis testing; https://travis-ci.org/pyblish/pyblish-base/jobs/410979563, that Python 2.6 fails because of deprecation.

Don't know why that did come up when removing Python 2.6 from Appveyor.