### PR TITLE
Edit Travis config to build a Python wheel (.whl) along with the .tar.gz file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ after_success:
 deploy:
   provider: pypi
   user: mottosso
-  distributions: "sdist"
+  distributions: "sdist bdist_wheel"
   password:
     secure: fwXIOGKn38gJFNkzlpvholQBhSBzNorOnMvs04JT3+Fdq6ys2TiUV6tlXHDwo6DkMY++USI19oD9NWlvg8gQaRJq4g2V/taazn8XDv1XnyKLzb6DnAT1ALilJtbIgotH/0QNOvkDP40a8UDwbelE0aR4AptNO1Ts7n1eERygENA=
   on:

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 7
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[bdist_wheel]
+universal = 1
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[metadata]
+# This includes the license file in the wheel.
+license_file = LICENSE.txt
+
 [bdist_wheel]
+# This produces a "universal" (Py2+3) wheel.
 universal = 1
 


### PR DESCRIPTION
Hello!

I noticed [`pyblish-qml` was building Python wheels](https://github.com/pyblish/pyblish-qml/blob/master/.travis.yml#L30) but this core repo and `pyblish-lite` were not.

As per [the Travis docs](https://docs.travis-ci.com/user/deployment/pypi/#uploading-different-distributions) this tiny change _should_ produce a .whl file as well as the .tar.gz already being made.

Python wheels are the most modern distribution format for pip packages. Pip will use the .whl when it is available and compared to .tar.gz they don't require extracting anything after pip downloads the file, and pip doesn't have to compile the extracted files to pregenerate the pycs either. They're basically a zipped package.

You can read more about them here: https://wheel.readthedocs.io/en/stable/
