### PR TITLE
Travis: Upgrade deploy runtime version from 2.6 to 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ deploy:
   on:
     tags: true
     all_branches: true
-    python: 2.6
+    python: 2.7
 sudo: false

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 7
-VERSION_PATCH = 1
+VERSION_PATCH = 2
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
(Followup to pull request #338.)

The `deploy:` block was saying to deploy on Python 2.6 yet in the build runtimes higher up in the file, 2.6 is not there (and rightfully so! it hit EOL in 2013) so I think the Travis error we got with the previous release attempt that said:

> Skipping a deployment with the pypi provider because this is not on the required runtime

...is *very likely* due to not being on the 2.6 runtime so the condition could not be met.

I hope this will solve the deployment and get us finally making some sweet universal wheels.