### PR TITLE
Add Python 3.7+ support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
 - 2.7
 - 3.5
+- 3.7
+- 3.8
 install:
 - pip install coveralls
 script:

--- a/pyblish/logic.py
+++ b/pyblish/logic.py
@@ -369,7 +369,8 @@ def Iterator(plugins, context, state=None):
 
         message = test(**state)
         if message:
-            raise StopIteration("Stopped due to %s" % message)
+            log.error("Stopped due to %s" % message)
+            return
 
         instances = instances_by_plugin(context, plugin)
         if plugin.__instanceEnabled__:

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This fixes issues with StopIteration being raised - it's still able to get caught so everything should continue to work normally.

However, in GUIs the StopIteration exception passed along a message that is now being printed directly via the `logging` module, so keep any eye out for any message you expect to appear inline anywhere, such as in your custom GUIs. If it's a problem, we can have a look at a different means of forwarding these messages, but they should also be interceptable via logging directly.