### PR TITLE
convert tuple ctx.obj["plugin_paths"] to list before concatenation

### DIFF
--- a/pyblish/cli.py
+++ b/pyblish/cli.py
@@ -198,6 +198,11 @@ def main(ctx,
     global _ctx
     _ctx = ctx
 
+    # Convert multi-arguments from tuple to list, see #357
+    plugin_paths = list(plugin_paths)
+    add_plugin_paths = list(add_plugin_paths)
+    data = list(data)
+
     level = LOG_LEVEL[logging_level]
     log.setLevel(level)
 
@@ -309,6 +314,10 @@ def publish(ctx,
 
     """
 
+    # Convert multi-arguments from tuple to list, see #357
+    targets = list(targets)
+    instances = list(instances)
+
     _start = time.time()  # Benchmark
 
     # Use `path` argument as initial data for context
@@ -355,7 +364,7 @@ def gui(ctx, package):
 
     with _cli_plugin(data=context.data) as plugin_path:
         environ["PYBLISHPLUGINPATH"] = os.pathsep.join(
-            list(ctx.obj["plugin_paths"]) + [plugin_path]
+            ctx.obj["plugin_paths"] + [plugin_path]
         )
 
         process = subprocess.Popen(

--- a/pyblish/cli.py
+++ b/pyblish/cli.py
@@ -355,7 +355,7 @@ def gui(ctx, package):
 
     with _cli_plugin(data=context.data) as plugin_path:
         environ["PYBLISHPLUGINPATH"] = os.pathsep.join(
-            ctx.obj["plugin_paths"] + [plugin_path]
+            list(ctx.obj["plugin_paths"]) + [plugin_path]
         )
 
         process = subprocess.Popen(

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 2
+VERSION_PATCH = 3
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
- ctx.obj["plugin_paths"] may be tuple which cause issues when trying to concatenate with list
- this fix will always convert the ctx.obj["plugin_paths"] to list to avoid this issue