### PR TITLE
Fix published signal being emitted from collect, validate, extract or integrate

### DIFF
--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -87,7 +87,13 @@ def publish_iter(context=None, plugins=None, targets=None):
                print result
 
     """
+    for result in _publish_iter(context, plugins, targets):
+        yield result
 
+    api.emit("published", context=context)
+
+
+def _publish_iter(context=None, plugins=None, targets=None):
     # Include "default" target when no targets are requested.
     targets = targets or ["default"]
 
@@ -171,8 +177,6 @@ def publish_iter(context=None, plugins=None, targets=None):
             print(error)
 
         yield result
-
-    api.emit("published", context=context)
 
     # Deregister targets
     for target in targets:
@@ -297,7 +301,7 @@ def _convenience_iter(order, context=None, plugins=None, targets=None):
         if lib.inrange(Plugin.order, order)
     )
 
-    for result in publish_iter(context, plugins, targets):
+    for result in _publish_iter(context, plugins, targets):
         yield result
 
 

--- a/pyblish/util.py
+++ b/pyblish/util.py
@@ -87,19 +87,25 @@ def publish_iter(context=None, plugins=None, targets=None):
                print result
 
     """
-    for result in _publish_iter(context, plugins, targets):
+    for result in _convenience_iter(context, plugins, targets):
         yield result
 
     api.emit("published", context=context)
 
 
-def _publish_iter(context=None, plugins=None, targets=None):
+def _convenience_iter(context=None, plugins=None, targets=None, order=None):
     # Include "default" target when no targets are requested.
     targets = targets or ["default"]
 
     # Must check against None, as objects be emptys
     context = api.Context() if context is None else context
     plugins = api.discover() if plugins is None else plugins
+
+    if order is not None:
+        plugins = list(
+            Plugin for Plugin in plugins
+            if lib.inrange(Plugin.order, order)
+        )
 
     # Register targets
     for target in targets:
@@ -252,57 +258,44 @@ def integrate(context=None, plugins=None, targets=None):
 
 
 def collect_iter(context=None, plugins=None, targets=None):
-    for result in _convenience_iter(api.CollectorOrder,
-                                    context, plugins, targets):
+    for result in _convenience_iter(context, plugins, targets,
+                                    order=api.CollectorOrder):
         yield result
 
     api.emit("collected", context=context)
 
 
 def validate_iter(context=None, plugins=None, targets=None):
-    for result in _convenience_iter(api.ValidatorOrder,
-                                    context, plugins, targets):
+    for result in _convenience_iter(context, plugins, targets,
+                                    order=api.ValidatorOrder):
         yield result
 
     api.emit("validated", context=context)
 
 
 def extract_iter(context=None, plugins=None, targets=None):
-    for result in _convenience_iter(api.ExtractorOrder,
-                                    context, plugins, targets):
+    for result in _convenience_iter(context, plugins, targets,
+                                    order=api.ExtractorOrder):
         yield result
 
     api.emit("extracted", context=context)
 
 
 def integrate_iter(context=None, plugins=None, targets=None):
-    for result in _convenience_iter(api.IntegratorOrder,
-                                    context, plugins, targets):
+    for result in _convenience_iter(context, plugins, targets,
+                                    order=api.IntegratorOrder):
         yield result
 
     api.emit("integrated", context=context)
 
 
-def _convenience(order, context=None, plugins=None, targets=None):
+def _convenience(context=None, plugins=None, targets=None, order=None):
     context = context if context is not None else api.Context()
 
-    for result in _convenience_iter(order, context, plugins, targets):
+    for result in _convenience_iter(context, plugins, targets, order):
         pass
 
     return context
-
-
-def _convenience_iter(order, context=None, plugins=None, targets=None):
-    targets = targets or ["default"]
-    plugins = plugins or api.discover()
-    plugins = list(
-        Plugin
-        for Plugin in plugins
-        if lib.inrange(Plugin.order, order)
-    )
-
-    for result in _publish_iter(context, plugins, targets):
-        yield result
 
 
 # Backwards compatibility

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 3
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -32,7 +32,7 @@ def test_convenience_plugins_argument():
     assert count["#"] == 0
 
     api.register_plugin(PluginA)
-    util._convenience(0.5, plugins=[PluginB])
+    util._convenience(plugins=[PluginB], order=0.5)
 
     assert count["#"] == 10, count
 


### PR DESCRIPTION
**Description**

The "published" signal is currently being emitted when we call the collect, validate, extract and integrate functions, despite these functions already emitting their own signal (e.g. "collected", "validated", etc.) This is because these functions all end up calling the _publish_iter_ function, which emits the "published" signal.

I'm not sure if this is the intended behavior, but it seems like a bug to me.

The _publish_ function is the only one that can be used to execute the plugins regardless of their phase, and it seems to make sense to emit the "published" signal when using it, as the name of the signal seems related to the function's name. However, when the collect, validate, extract or integrate functions are used, it seems implied that we'd deliberately want to execute a single specific phase and would thereby expect a different signal.

**Expected results**

It appears that the "published" signal is meant to be emitted when the whole publish process is done, but when we call the collect, validate and extract functions individually (and to a certain extent the integrate function), the publish process is incomplete, and therefore the "published" signal should not be emitted.

In fact, this seems to be the behavior of the Pyblish UIs (QML and Lite), but these UIs don't appear to use the _publish_ or _publish_iter_ functions, as they instead appear to have their own implementations of how to execute plugins and emit signals.

**Short reproducible**

Imagine creating a small API where we want to split the collect, validate and extract/integrate phases like so:

```
import pyblish.api
import pyblish.lib
import pyblish.util


class Publisher(object):

    def __init__(self):
        self._context = None
        self._collected = False
        self._validated = False

    def collect(self):
        self._context = pyblish.util.collect()
        self._collected = True
        self._validated = False

    def validate(self):
        if not self._collected:
            self.collect()

        pyblish.util.validate(self._context)
        self._validated = True

    def publish(self):
        if not self._validated:
            self.validate()

        plugins = [
            plugin for plugin in pyblish.api.discover()
            if not pyblish.lib.inrange(number=plugin.order, base=pyblish.api.CollectorOrder)
            and not pyblish.lib.inrange(number=plugin.order, base=pyblish.api.ValidatorOrder)
        ]

        pyblish.util.publish(self._context, plugins)


class Collector(pyblish.api.ContextPlugin):
    order = pyblish.api.CollectorOrder

    def process(self, context):
        pass


class Validator(pyblish.api.ContextPlugin):
    order = pyblish.api.ValidatorOrder

    def process(self, context):
        pass


class Extractor(pyblish.api.ContextPlugin):
    order = pyblish.api.ExtractorOrder

    def process(self, context):
        pass


class Integrator(pyblish.api.ContextPlugin):
    order = pyblish.api.IntegratorOrder

    def process(self, context):
        pass


def callMeWhenPublishedIsOver(context):
    print("### GOOD NEWS! The publish is over!")


pyblish.api.deregister_all_paths()
pyblish.api.deregister_all_plugins()
pyblish.api.deregister_all_callbacks()

pyblish.api.register_callback("published", callMeWhenPublishedIsOver)
pyblish.api.register_plugin(Collector)
pyblish.api.register_plugin(Validator)
pyblish.api.register_plugin(Extractor)
pyblish.api.register_plugin(Integrator)

publisher = Publisher()
publisher.collect()
publisher.validate()
publisher.publish()
```
By executing this code, we currently end up calling the _callMeWhenPublishedIsOver_ function 3 times, instead of the expected 1 time, but if we only register the callback and then use either the Pyblish-QML or Pyblish-Lite UIs, the callback function will only be called once, which is expected.