### PR TITLE
Remove 'vendorised' libraries from sys path

### DIFF
--- a/pyblish/vendor/__init__.py
+++ b/pyblish/vendor/__init__.py
@@ -1,5 +1,0 @@
-import os
-import sys
-
-# Append vendor plugins to PYTHONPATH
-sys.path.insert(0, os.path.dirname(__file__))

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 4
+VERSION_PATCH = 6
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info


### PR DESCRIPTION
This is not required anymore as these libraries are all imported via the
'vendor' module. It also prevent these libraries to interfere with the
environment.

This resolves #365 