### PR TITLE
Support loading unicode contained plugin in Python 3

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1337,7 +1337,7 @@ def discover(type=None, regex=None, paths=None):
             module.__file__ = abspath
 
             try:
-                with open(abspath) as f:
+                with open(abspath, "rb") as f:
                     six.exec_(f.read(), module.__dict__)
 
                 # Store reference to original module, to avoid

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 3
+VERSION_PATCH = 4
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1006,3 +1006,22 @@ def test_deregister_discovery():
     pyblish.api.deregister_discovery_filter(my_plugin_filter)
     plugins = pyblish.api.discover()
     assert len(plugins) == 1, plugins
+
+
+@with_setup(lib.setup_empty, lib.teardown)
+def test_discovering_unicode_contained_plugin():
+    unicode_plugin = b"""
+import pyblish.api
+
+class UnicodePlugin(pyblish.api.InstancePlugin):
+    label = "\xf0\x9f\xa4\xa8"
+"""
+
+    with lib.tempdir() as d:
+        pyblish.api.register_plugin_path(d)
+
+        with open(os.path.join(d, "unicode_plugin.py"), "wb") as f:
+            f.write(unicode_plugin)
+
+        plugins = [p.__name__ for p in pyblish.api.discover()]
+        assert plugins == ["UnicodePlugin"]


### PR DESCRIPTION
### What's changed

Some of our plugins contain Unicode characters in plugin's `label` attribute or doc string. Those plugins which **registered in plugin path** can be discovered via Pyblish in Python 2 but fails in Python 3 due to bytes encoding issue.

The solution was simple, just change the `open` mode into `"rb"` in `api.discover`.

### Example

1. Save a plugin with Unicode character

```python
# /path/to/plugin/unicode_plugin.py

import pyblish.api

class UnicodePlugin(pyblish.api.InstancePlugin):

    order = pyblish.api.CollectorOrder
    label = "🤨"  # Unicode emoji

    def process(self, instance):
        return True

```

2. In Python 3, register the dir path and run `pyblish.api.discover` to see the test result

```python
import pyblish.api

# Remove other plugins for testing
pyblish.api.deregister_all_plugins()
pyblish.api.deregister_all_paths()

# Register our only Unicode contained plugin
pyblish.api.register_plugin_path("/path/to/plugin")

# AssertionError will raised without this PR
assert len(pyblish.api.discover()) == 1

```
