### PR TITLE
Extend plugin sorting logic

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -46,16 +46,21 @@ Intersection = 1 << 0
 Subset = 1 << 1
 Exact = 1 << 2
 
-# Check for duplicate plugin names. This is to preserve backwards compatility.
+# Check for duplicate plugin names. This is to preserve backwards compatibility.
 ALLOW_DUPLICATES = bool(os.getenv("PYBLISH_ALLOW_DUPLICATE_PLUGIN_NAMES"))
 
-# Check for strict data types. This is to preserve backwards compatility
+# Check for strict data types. This is to preserve backwards compatibility
 STRICT_DATATYPES = bool(os.getenv("PYBLISH_STRICT_DATATYPES"))
+
+# Sort plugins per order and per type (Context Plugin before Instance plugin).
+# This is to preserve backwards compatibility
+SORT_PER_ORDER_AND_TYPE = bool(os.getenv("PYBLISH_SORT_PER_ORDER_AND_TYPE"))
 
 # Check for early adopters.
 EARLY_ADOPTER = bool(os.getenv("PYBLISH_EARLY_ADOPTER"))
 ALLOW_DUPLICATE_PLUGINS = EARLY_ADOPTER or ALLOW_DUPLICATES
 STRICT_DATATYPES = EARLY_ADOPTER or STRICT_DATATYPES
+SORT_PER_ORDER_AND_TYPE = EARLY_ADOPTER or SORT_PER_ORDER_AND_TYPE
 
 
 class Provider():
@@ -1519,8 +1524,9 @@ def sort(plugins):
 
     *But may be overridden.
 
-    For plug-ins with the same order, ContextPlugin will always be sorted before
-    InstancePlugin.
+    If the PYBLISH_SORT_PER_ORDER_AND_TYPE or PYBLISH_EARLY_ADOPTER environment
+    variable is set to "1, ContextPlugin will always be sorted before
+    InstancePlugin for the same order.
 
     Arguments:
         plugins (list): Plug-ins to sort
@@ -1534,5 +1540,8 @@ def sort(plugins):
         """Return 1 if plugin operates on instances, 0 otherwise."""
         return 1 if plugin.__instanceEnabled__ else 0
 
-    plugins.sort(key=lambda p: (p.order, _sort_by_type(p)))
+    if SORT_PER_ORDER_AND_TYPE:
+        plugins.sort(key=lambda p: (p.order, _sort_by_type(p)))
+    else:
+        plugins.sort(key=lambda p: p.order)
     return plugins

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1519,6 +1519,9 @@ def sort(plugins):
 
     *But may be overridden.
 
+    For plug-ins with the same order, ContextPlugin will always be sorted before
+    InstancePlugin.
+
     Arguments:
         plugins (list): Plug-ins to sort
 
@@ -1527,5 +1530,9 @@ def sort(plugins):
     if not isinstance(plugins, list):
         raise TypeError("plugins must be of type list")
 
-    plugins.sort(key=lambda p: p.order)
+    def _sort_by_type(plugin):
+        """Return 1 if plugin operates on instances, 0 otherwise."""
+        return 1 if plugin.__instanceEnabled__ else 0
+
+    plugins.sort(key=lambda p: (p.order, _sort_by_type(p)))
     return plugins

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1029,15 +1029,23 @@ class UnicodePlugin(pyblish.api.InstancePlugin):
 
 def test_sort_plugins():
     """Ensure that plugins order is correct."""
-    class Plugin1(pyblish.plugin.ContextPlugin):
-        order = 1
+    pyblish.plugin.SORT_PER_ORDER_AND_TYPE = True
 
     class Plugin2(pyblish.plugin.InstancePlugin):
+        order = 1
+
+    class Plugin1(pyblish.plugin.ContextPlugin):
         order = 1
 
     class Plugin3(pyblish.plugin.ContextPlugin):
         order = 2
 
-    plugins = [Plugin3, Plugin1, Plugin2]
+    plugins = [Plugin3, Plugin2, Plugin1]
     pyblish.plugin.sort(plugins)
     assert plugins == [Plugin1, Plugin2, Plugin3]
+
+    # Restore state, for subsequent tests
+    # NOTE: This assumes the test succeeds. If it fails, then
+    # subsequent tests can fail because of it.
+    pyblish.plugin.SORT_PER_ORDER_AND_TYPE = False
+

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1025,3 +1025,19 @@ class UnicodePlugin(pyblish.api.InstancePlugin):
 
         plugins = [p.__name__ for p in pyblish.api.discover()]
         assert plugins == ["UnicodePlugin"]
+
+
+def test_sort_plugins():
+    """Ensure that plugins order is correct."""
+    class Plugin1(pyblish.plugin.ContextPlugin):
+        order = 1
+
+    class Plugin2(pyblish.plugin.InstancePlugin):
+        order = 1
+
+    class Plugin3(pyblish.plugin.ContextPlugin):
+        order = 2
+
+    plugins = [Plugin3, Plugin1, Plugin2]
+    pyblish.plugin.sort(plugins)
+    assert plugins == [Plugin1, Plugin2, Plugin3]


### PR DESCRIPTION
Ensure that ContextPlugin are sorted before InstancePlugin when plugins have the same order.

This resolves #368 