### PR TITLE
Add "warning" and "failedOrWarning" action types

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -364,6 +364,8 @@ class MetaAction(type):
                           "notProcessed",
                           "processed",
                           "failed",
+                          "warning",
+                          "failedOrWarning",
                           "succeeded"):
             cls.__error__ = (
                 "Action had an unrecognised value "
@@ -391,6 +393,9 @@ class Action():
             - "processed": The plug-in has been processed
             - "succeeded": The plug-in has been processed, and succeeded
             - "failed": The plug-in has been processed, and failed
+            - "warning": The plug-in has been processed, and had a warning
+            - "failedOrWarning": The plug-in has been processed, and failed or
+              had a warning
         icon: Name, relative path or absolute path to image for
             use as an icon of this action. For relative paths,
             the current working directory of the host is used and


### PR DESCRIPTION
This PR is related to a pyblish-lite PR: https://github.com/pyblish/pyblish-lite/pull/116

This basically adds support for having actions on plugins that were processed with a warning instead of an error. The existing "failed" action type being reserved for plugins that were processed with errors, a new "warning" action type has been added for those processed with warnings, and another "failedOrWarning" was added to handle both cases in a single action.