### PR TITLE
Convert emmited log messages to string

### DIFF
--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -50,7 +50,8 @@ class MessageHandler(logging.Handler):
 
     def emit(self, record):
         if record.name.startswith("pyblish"):
-            self.records.append(str(record))
+            record.msg = str(record.msg)
+            self.records.append(record)
 
 
 def extract_traceback(exception, fname=None):

--- a/pyblish/lib.py
+++ b/pyblish/lib.py
@@ -50,7 +50,7 @@ class MessageHandler(logging.Handler):
 
     def emit(self, record):
         if record.name.startswith("pyblish"):
-            self.records.append(record)
+            self.records.append(str(record))
 
 
 def extract_traceback(exception, fname=None):


### PR DESCRIPTION
## Issue
Objects passed to plugin's logger object are not converted to string in `MessageHandler` so GUI logging may not show object data at the moment of logging it.

## How to replicate bug
Put these in plugin logic:
```
my_data = [1]
self.log.debug(my_data)
my_data.append(2)
self.log.debug(my_data)
```

Run the plugin in Pyblish UI and see UI terminal output. Should see:
```
DEBUG: [1,2]
DEBUG: [1,2]
```

## Suggested solution
Convert message on all emmited records to string.