### PR TITLE
add support for kwargs in instance init

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -770,8 +770,7 @@ class Context(AbstractEntity):
 
         """
 
-        instance = Instance(name, parent=self)
-        instance.data.update(kwargs)
+        instance = Instance(name, parent=self, **kwargs)
         return instance
 
     def __getitem__(self, item):
@@ -820,10 +819,11 @@ class Instance(AbstractEntity):
 
     """
 
-    def __init__(self, name, parent=None):
+    def __init__(self, name, parent=None, **kwargs):
         super(Instance, self).__init__(name, parent)
         self._data["family"] = "default"
         self._data["name"] = name
+        self._data.update(kwargs)
 
     def __eq__(self, other):
         return self._id == getattr(other, "id", None)

--- a/pyblish/version.py
+++ b/pyblish/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 1
 VERSION_MINOR = 8
-VERSION_PATCH = 8
+VERSION_PATCH = 9
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -651,6 +651,14 @@ def test_cooperative_collection():
     assert count["#"] == 11, count
 
 
+def test_instance_kwarg_init():
+    # check if all kwargs get passed to the metadata dict of the instance
+    mock_families = ['mock_family1', 'mock_family2']
+    inst = pyblish.api.Instance(name='test', madeup_kwarg=13, families=mock_families)
+    assert inst.data['madeup_kwarg'] == 13
+    assert inst.data['families'] == mock_families
+
+
 def test_actions_and_explicit_plugins():
     """Actions work with explicit plug-ins"""
 


### PR DESCRIPTION
now instance() and context.create_instance are interchangable, before it would error out since only some kwars were shared.

see forum post explaining it https://forums.pyblish.com/t/instance-vs-create-instance/658