### PR TITLE
add support to register plugins by module path 

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1321,12 +1321,22 @@ def discover(type=None, regex=None, paths=None):
     # Include plug-ins from registered paths
     for path in paths or plugin_paths():
         path = os.path.normpath(path)
-        if not os.path.isdir(path):
+
+        if not os.path.exists(path):
             continue
 
+        # check if folder or file
+        if os.path.isdir(path):
+            file_paths = [os.path.join(path, fname) for fname in os.listdir(path)]
+        elif os.path.isfile(path):
+            # todo check if valid path?
+            file_paths = [path]
+
         # register plugins from modules in folder
-        for fname in os.listdir(path):
+        for abspath in file_paths:
+
             module = _valid_plugin_module(abspath)
+
             if module:
                 plugins_in_module = plugins_from_module(module)
                 _register_plugins_helper(plugins_in_module, plugin_names, plugins, module=module)

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1365,14 +1365,17 @@ def _valid_plugin_module(abspath):
     path, fname = abspath.rsplit(split_char, 1)
 
     if fname.startswith("_"):
+        log.debug('Skipped: private module: "%s"', fname)
         return
 
     if not os.path.isfile(abspath):
+        log.debug('Skipped: "%s" is not a file', abspath)
         return
 
     mod_name, mod_ext = os.path.splitext(fname)
 
     if not mod_ext == ".py":
+        log.debug('Skipped: "%s" is not a python file', fname)
         return
 
     module = types.ModuleType(mod_name)


### PR DESCRIPTION
**TLDR**: this PR adds support to register a plugin with the path to a python file(module). allowing you to register individual files without having to change your folder structure.

**Description**:

atm pyblish only supports registering a plugin either 
- by registering the plugin class instance
- or registering the folder containing the python files (modules) which contain the plugins

the paths are also saved in registered paths, and are returned by
- registered_paths
- _registered_paths
- plugin_paths()

i chose to reuse this variable since it requires minimum changes to the codebase, and is a lot cleaner than having a second var.
it also reads nice, registered paths contains all registered paths. both file and folder.

this was tested with pyblish QML and lite.

regarding potentially breaking old pipelines/ pyblish setups.
since before a file path was not allowed in registered paths. no one will have any workflows with files in the registered plugin paths.
this leads to my assumption it will be backwards compatible.

the main function using plugin_paths in the pyblish API is discover. which now handles filepaths correctly.
the CLI does not require changes i believe. 

incase there is a test that checks if registered paths does not contain a filepath, this test will now fail.
