### PR TITLE
register plugin path issues

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -547,6 +547,29 @@ def test_deregister_plugin_path_pathlib():
     for path in input_to_test:
         helper_deregister_plugin_path(path)
 
+def helper_create_path_input():
+    input_to_test = []
+    input_to_test.append(u"c:\some\special\södär\testpath".encode('utf-8'))  # unicode input
+    input_to_test.append(b'c:\some\special\s\xc3\xb6d\xc3\xa4r\testpath')  # bytestring input
+    input_to_test.append(b"c:\\bytes\\are/cool")  # bytestring input
+    input_to_test.append("c:/just/a/average/path")  # string input
+    input_to_test.append(r"c:\just\a\average\path\v2")  # raw string input with different slashes
+    return input_to_test
+
+
+def test_register_plugin_path():
+    """test various types of input for plugin path registration"""
+    input_to_test = helper_create_path_input()
+    for path in input_to_test:
+        helper_register_plugin_path(path)
+
+
+def test_deregister_plugin_path_pathlib():
+    """test various types of input for plugin path registration"""
+    input_to_test = helper_create_path_input()
+    for path in input_to_test:
+        helper_deregister_plugin_path(path)
+
 
 @mock.patch("pyblish.plugin.__explicit_process")
 def test_implicit_explicit_branching(func):


### PR DESCRIPTION
created a register path test while working on previous PR
and noticed odd behaviour, described in issue https://github.com/pyblish/pyblish-base/issues/379

## this new test influences test behaviour of unrelated tests
in py2 and py3
a test that should fail or be skipped, does not run
This came to my attention while working on pathlib deregister support https://github.com/pyblish/pyblish-base/pull/384 .
The deregister path test stopped running when adding this new binary string test.
The test is not skipped, and did not fail, it inexplicably wasn't picked up by nose.
When removing the new test commited in this PR it worked again.

we can see this reflected in the logs https://ci.appveyor.com/project/mottosso/pyblish/builds/42230403/job/oefioqph7sbsnbqn
pathlib deregister test does not run

##  issue  when using binary string to register plugin paths
in py 3
binary string fails in py3+

register the following path
```python
u"c:\some\special\södär\testpath".encode('utf-8')
```
results in failed test
`AssertionError: b'c:\some\special\s\xc3\xb6d\xc3\xa4r\testpath' not in ['C:\\projects\\pyblish\\pyblish\\plugins', 'server\\plugins', b'c:\\some\\special\\s\xc3\xb6d\xc3\xa4r\testpath']`

see old PR  https://github.com/pyblish/pyblish-base/pull/383 for more info