### PR TITLE
Hash for AbstractEntity

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -713,6 +713,12 @@ class AbstractEntity(list):
         if parent is not None:
             parent.append(self)
 
+    def __hash__(self):
+        return self.id
+
+    def __eq__(self, other):
+        return self.id == other.id
+
     @property
     def id(self):
         return self._id


### PR DESCRIPTION
# Feature request

## Goal
Allow to compare "AbstractEntity" objects directly, without the need to access the "id" property.

## Motivation
When building a list containing several "AbstractEntity" objects (of derived types "Instance" or "Context"), in order to check if an element is already in the list it is currently required to explicitly compare the "id" property of each object.
The common "in" operator cannot be used as the objects are not hashable:
```python
if instance in list: # raises an exception
    ...
```

## Suggested implementation
Add the definition of the "__hash__" and "__eq__" functions to the "AbstractEntity" class.
In both function, the "id" property is used to determine equality.