### PR TITLE
add discover_gui (without introducing ui dependencies !)

### DIFF
--- a/pyblish/gui.py
+++ b/pyblish/gui.py
@@ -1,0 +1,37 @@
+import pyblish.api
+
+
+def show(parent=None):
+    """Try showing the most desirable GUI
+    This function cycles through the currently registered
+    graphical user interfaces, if any, and presents it to
+    the user.
+
+    parent (QWidget): the Parent widget to pass to GUI, preferably parented under QApplication
+    to avoid any dependencies on Qt, pyside2, or your favorite QT wrapper:
+    if you don't have a QApplication instance, instantiate one yourself
+
+    return a QWidget instance
+    """
+    gui_show = _discover_gui()
+
+    if gui_show is None:
+        raise RuntimeError("No GUI found")
+    else:
+        return gui_show(parent)
+
+
+def _discover_gui():
+    """Return the most desirable of the currently registered GUIs"""
+
+    # Prefer last registered
+    guis = reversed(pyblish.api.registered_guis())
+
+    for gui in guis:
+        try:
+            gui_show = __import__(gui).show
+        except (ImportError, AttributeError) as e:
+            print("Failed to import GUI: %s" % gui, e)
+            continue
+        else:
+            return gui_show


### PR DESCRIPTION
## Problem:
Pyblish base let's us register guis with `pyblish.api.register_gui` , but not show them. 😞 

Each dcc implementation of pyblish has a show function, but pyblish base does not.
e.g. in pyblish-maya we can do:
```python
import pyblish_maya
pyblish_maya.show()
```

but in pyblish-base we can't do:
```python
import pyblish
pyblish.show()
```

`show()` launches the registered UI, and on fail falls back to the next registered UI.
However this code is duplicated across each dcc implementation, and not available in pyblish base.
Moving this code to base would make it easier to make dcc implementations, and enable devs to use this functionality for non dcc plugins.

## Solution
this PR implements the discover_gui method from pyblish_maya & pyblish_3dsmax in pyblish base, without creating a UI dependency

now we can do this
```python
import pyblish.api
import pyblish.gui
pyblish.api.register_gui('pyblish_lite')
pyblish.gui.show()
```
## Note
- it might even be worth movign the show function to pyblish so we can do `pyblish.show()`


Pyblish base already allows us to show both default qml & lite explicitly.
```python
import pyblish_qml
pyblish_qml .show()
```
```python
import pyblish_lite
pyblish_lite.show()
```