### PR TITLE
Added fix for inspect.getargspec in Py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ build
 playground.py
 *.sublime-*
 __pycache__
+*.p4env
+*pyrightconfig.json

--- a/pyblish/compat.py
+++ b/pyblish/compat.py
@@ -4,6 +4,12 @@ import re
 import inspect
 import warnings
 from . import plugin, lib, logic
+from .vendor import six
+
+if six.PY2:
+    get_arg_spec = inspect.getargspec
+else:
+    get_arg_spec = inspect.getfullargspec
 
 # Aliases
 Selector = plugin.Collector
@@ -216,7 +222,7 @@ def process(func, plugins, context, test=None):
             if hasattr(__context, "__call__"):
                 context = __context()
 
-            args = inspect.getargspec(Plugin.process).args
+            args = get_arg_spec(Plugin.process).args
 
             # Backwards compatibility with `asset`
             if "asset" in args:

--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -37,6 +37,11 @@ from . import (
 from . import lib
 from .vendor import iscompatible, six
 
+if six.PY2:
+    get_arg_spec = inspect.getargspec
+else:
+    get_arg_spec = inspect.getfullargspec
+
 log = logging.getLogger("pyblish.plugin")
 
 __metaclass__ = type  # Make all classes new-style
@@ -87,7 +92,7 @@ class Provider():
 
     @classmethod
     def args(cls, func):
-        return [a for a in inspect.getargspec(func)[0]
+        return [a for a in get_arg_spec(func)[0]
                 if a not in ("self", "cls")]
 
     def invoke(self, func):
@@ -147,7 +152,7 @@ def evaluate_enabledness(plugin):
     plugin.__contextEnabled__ = False
     plugin.__instanceEnabled__ = False
 
-    args_ = inspect.getargspec(plugin.process).args
+    args_ = get_arg_spec(plugin.process).args
 
     if "instance" in args_:
         plugin.__instanceEnabled__ = True
@@ -314,7 +319,7 @@ IntegratorOrder = 3
 
 def validate_argument_signature(plugin):
     """Ensure plug-in processes either 'instance' or 'context'"""
-    if not any(arg in inspect.getargspec(plugin.process).args
+    if not any(arg in get_arg_spec(plugin.process).args
                for arg in ("instance", "context")):
         plugin.__invalidSignature__ = True
 


### PR DESCRIPTION
This PR adds Py3 specific import for `inspect.getfullargspec` as `inspect.getargspec` is depreciated since Py3.0.
More info here: https://docs.python.org/3/library/inspect.html#inspect.getargspec

This also removes warnings output from Pyblish upon plugin discovery which prints the following 3 times per plugin discovered: `"DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec(), at line 350, in "...\pyblish\plugin.py""`.
This has a noticeable impact on startup performance for projects with a large number of plugins.

Py2: functionality remains unchanged
Py3: tested in Py37 + Py39