### PR TITLE
Add 'context' key to 'result' dict

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -504,6 +504,7 @@ def __explicit_process(plugin, context, instance=None, action=None):
         "records": list(),
         "duration": None,
         "progress": 0,
+        "context": context,
     }
 
     if not action:
@@ -571,6 +572,7 @@ def __implicit_process(plugin, context, instance=None, action=None):
         "records": list(),
         "duration": None,
         "progress": 0,
+        "context": context,
     }
 
     if not action:


### PR DESCRIPTION
## Changelog Description
This PR adds `context` key to `result` dict inside `plugin.process`

## Additional Info 1
This PR is very helpful for people who develop some debugging tools like https://gist.github.com/BigRoy/1972822065e38f8fae7521078e44eca2 

This PR avoids the need to create custom redundant events.

## Additional Info 2
Things I tried: 
- Accessing context via `result["instance"].context` but this only works for instance plugins.
- Passing the context as argument to lib.emit -> `lib.emit("pluginProcessed", result=result, context=context)` but apparently this affects every single call so we will get an error `TypeError: on_plugin_processed() got an unexpected keyword argument 'context'`
- The backward friendly solution was just to update the result key.