### PR TITLE
Fix discovery for plugins with dataclasses and type annotations

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -1361,13 +1361,12 @@ def discover(type=None, regex=None, paths=None):
             module.__file__ = abspath
 
             try:
-                with open(abspath, "rb") as f:
-                    six.exec_(f.read(), module.__dict__)
-
                 # Store reference to original module, to avoid
                 # garbage collection from collecting it's global
                 # imports, such as `import os`.
                 sys.modules[abspath] = module
+                with open(abspath, "rb") as f:
+                    six.exec_(f.read(), module.__dict__)
 
             except Exception as err:
                 log.error("Skipped: \"%s\" (%s)", mod_name, err)


### PR DESCRIPTION
## Problem

When plugin is using type annotations and dataclass like so:

```python
"""Test dataclass in publish plugin."""
from __future__ import annotations

from dataclasses import dataclass
from typing import ClassVar

import pyblish.api


@dataclass
class TestPublishData:
    """Test dataclass in publish plugin."""
    id: str
    name: str
    description: str
    version: str


class TestPublishPlugin(pyblish.api.ContextPlugin):
    """Test publish plugin."""
    label = "Test Publish Plugin"
    families: ClassVar[list[str]] = ["*"]

    def process(self, context: pyblish.api.Context) -> None:
        """Process the plugin."""
        _ = TestPublishData(
            id="test",
            name="Test",
            description="Test dataclass in publish plugin.",
            version="1.0.0"
        )
```

discovery will skip it because of `'NoneType' object has no attribute '__dict__'` error. The root of this is that *dataclass* is looking into `sys.modules` when it is dealing with type hints so it needs to have it available before it gets executed.

**Similar issue:** https://github.com/ynput/ayon-core/issues/1199