### PR TITLE
Bug with settign breakpoints in discovered pyblish plugins

### DIFF
--- a/pyblish/plugin.py
+++ b/pyblish/plugin.py
@@ -21,7 +21,6 @@ import warnings
 import contextlib
 import uuid
 
-
 # Local library
 from . import (
     __version__,
@@ -39,10 +38,8 @@ from . import lib
 from .vendor import iscompatible, six
 
 if six.PY2:
-    import imp
     get_arg_spec = inspect.getargspec
 else:
-    import importlib.machinery
     get_arg_spec = inspect.getfullargspec
 
 log = logging.getLogger("pyblish.plugin")
@@ -1360,18 +1357,13 @@ def discover(type=None, regex=None, paths=None):
                 log.debug("Skipped: \"%s\",\"%s\", not end in .py", mod_name, mod_ext)
                 continue
 
-            
-            
+            module = types.ModuleType(mod_name)
+            module.__file__ = abspath
+
             try:
-                if six.PY2:
-                    module = imp.load_module(mod_name)
-                    module.__file__ = abspath
-                else:
-                    loader = importlib.machinery.SourceFileLoader(mod_name,abspath)
-                    module = types.ModuleType(mod_name)
-                    module.__file__ = abspath
-                    # exec might cause issues with python < 3.4
-                    loader.exec_module(module)
+                with open(abspath, "rb") as f:
+                    code = compile(f.read(),abspath,"exec")
+                    six.exec_(code, module.__dict__)
 
                 # Store reference to original module, to avoid
                 # garbage collection from collecting it's global


### PR DESCRIPTION
## The Problem

I encountered the issue that setting breakpoints in discovered plugins does not trigger that breakpoint. If the plugin has been registered manually, it will, but using ```pyblish.api.discover()``` it will go past the breakpoint in the plugin

## How to reproduce the problem

I have created a [seperate repository](https://github.com/quitinit/pyblish-debug) with a small example. Essentially, you set a breakpoint inside a plugin that has been added to the plugin_path before. When running it in vscode with the provided .vscode settings, it should trigger a breakpoint. However it does not.

## The reason for the bug

The import mechanism is not quite correct in the discover method. 
In plugin.py we use six.exec_ on a raw bytestream. This does import the plugin, however, for each object inside the module, python typically generates a __code__ method. When using the normal import statement, python compiles the code before running exec on it. Crucially, with that compile step it associates the __code__ method with a file. When the code then triggers a breakpoint, the debugger knows in which file it does so and can halt the execution. With the current approach there is no file associated. I attached two screenshots  

![image](https://github.com/user-attachments/assets/a379f004-dbd9-441c-98b5-ad0199ad0cf2)
*how it is right. now*
![image](https://github.com/user-attachments/assets/318df89b-f865-4cb5-97c0-059a976466b4)
*how it should be*

My research on this topic is backed by [this article](https://tenthousandmeters.com/tag/python-behind-the-scenes/)

