### PR TITLE
added exclude to setup to not copy tests when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     author_email="marcus@abstractfactory.io",
     url="https://github.com/pyblish/pyblish",
     license="LGPL",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests","tests.*"]),
     zip_safe=False,
     classifiers=classifiers,
     package_data={


### PR DESCRIPTION
When installing pyblish-base the tests directory is copied with it.
By excluding the tests we shrink the install size a little bit