### PR TITLE
Compatibility: use `pytest` instead of `nose`

### DIFF
--- a/pyblish/vendor/iscompatible.py
+++ b/pyblish/vendor/iscompatible.py
@@ -2,7 +2,7 @@
 Python versioning with requirements.txt syntax
 ==============================================
 
-iscompatible v\ |version|. gives you the power of the pip requirements.txt
+iscompatible gives you the power of the pip requirements.txt
 syntax for everyday python packages, modules, classes or arbitrary
 functions.
 

--- a/run_testsuite.py
+++ b/run_testsuite.py
@@ -6,7 +6,7 @@ import warnings
 path = os.path.dirname(__file__)
 sys.path.insert(0, path)
 
-import nose
+import pytest
 from pyblish.vendor import mock
 
 warnings.warn = mock.MagicMock()
@@ -14,5 +14,5 @@ warnings.warn = mock.MagicMock()
 
 if __name__ == '__main__':
     argv = sys.argv[:]
-    argv.extend(['--exclude=vendor', '--with-doctest', '--verbose'])
-    nose.main(argv=argv)
+    argv.extend(['--ignore=pyblish/vendor', '--doctest-modules', '--verbose', 'tests/'])
+    sys.exit(pytest.main(argv))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Pytest configuration and fixtures for pyblish tests."""
+import pytest
+from tests import lib
+
+
+@pytest.fixture
+def setup_and_teardown():
+    """Fixture that runs setup() before test and teardown() after."""
+    lib.setup()
+    yield
+    lib.teardown()
+
+
+@pytest.fixture
+def setup_empty_and_teardown():
+    """Fixture that runs setup_empty() before test and teardown() after."""
+    lib.setup_empty()
+    yield
+    lib.teardown()
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,25 +3,23 @@ import sys
 import shutil
 import tempfile
 
+import pytest
 import pyblish
 import pyblish.cli
 import pyblish.api
-from nose.tools import (
-    with_setup,
-    assert_equals,
-)
 from pyblish.vendor.click.testing import CliRunner
-from . import lib
+from tests import lib
 
 self = sys.modules[__name__]
 
 
-def setup():
-    self.tempdir = tempfile.mkdtemp()
-
-
-def teardown():
-    shutil.rmtree(self.tempdir)
+@pytest.fixture
+def tempdir():
+    path = tempfile.mkdtemp()
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path)
 
 
 def ctx():
@@ -51,8 +49,7 @@ def test_visualise_environment_paths():
             os.environ["PYBLISHPLUGINPATH"] = current_path
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_publishing():
+def test_publishing(setup_empty_and_teardown):
     """Basic publishing works"""
 
     count = {"#": 0}
@@ -83,8 +80,7 @@ def test_publishing():
     assert count["#"] == 111, count
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_environment_host_registration():
+def test_environment_host_registration(setup_and_teardown):
     """Host registration from PYBLISH_HOSTS works"""
 
     count = {"#": 0}
@@ -129,28 +125,20 @@ def test_environment_host_registration():
     assert count["#"] == 11, count
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_show_gui():
+def test_show_gui(setup_and_teardown, tempdir):
     """Showing GUI through cli works"""
 
-    with tempfile.NamedTemporaryFile(dir=self.tempdir,
-                                     delete=False,
-                                     suffix=".py") as f:
+    with tempfile.NamedTemporaryFile(dir=tempdir, delete=False, suffix=".py") as f:
         module_name = os.path.basename(f.name)[:-3]
         f.write(b"""\
 def show():
-    print("Mock GUI shown successfully")
+    print('Mock GUI shown successfully')
 
 if __name__ == '__main__':
     show()
 """)
 
-    pythonpath = os.pathsep.join([
-        self.tempdir,
-        os.environ.get("PYTHONPATH", "")
-    ])
-
-    print(module_name)
+    pythonpath = os.pathsep.join([tempdir, os.environ.get("PYTHONPATH", "")])
 
     runner = CliRunner()
     result = runner.invoke(
@@ -158,31 +146,24 @@ if __name__ == '__main__':
         env={"PYTHONPATH": pythonpath}
     )
 
-    assert_equals(result.output.splitlines()[-1].rstrip(),
-                  "Mock GUI shown successfully")
-    assert_equals(result.exit_code, 0)
+    assert result.output.splitlines()[-1].rstrip() == "Mock GUI shown successfully"
+    assert result.exit_code == 0
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_uses_gui_from_env():
+def test_uses_gui_from_env(setup_and_teardown, tempdir):
     """Uses gui from environment var works"""
 
-    with tempfile.NamedTemporaryFile(dir=self.tempdir,
-                                     delete=False,
-                                     suffix=".py") as f:
+    with tempfile.NamedTemporaryFile(dir=tempdir, delete=False, suffix=".py") as f:
         module_name = os.path.basename(f.name)[:-3]
         f.write(b"""\
 def show():
-    print("Mock GUI shown successfully")
+    print('Mock GUI shown successfully')
 
 if __name__ == '__main__':
     show()
 """)
 
-    pythonpath = os.pathsep.join([
-        self.tempdir,
-        os.environ.get("PYTHONPATH", "")
-    ])
+    pythonpath = os.pathsep.join([tempdir, os.environ.get("PYTHONPATH", "")])
 
     runner = CliRunner()
     result = runner.invoke(
@@ -193,57 +174,46 @@ if __name__ == '__main__':
         }
     )
 
-    assert_equals(result.output.splitlines()[-1].rstrip(),
-                  "Mock GUI shown successfully")
-    assert_equals(result.exit_code, 0)
+    assert result.output.splitlines()[-1].rstrip() == "Mock GUI shown successfully"
+    assert result.exit_code == 0
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_passing_data_to_gui():
+def test_passing_data_to_gui(setup_and_teardown, tempdir):
     """Passing data to GUI works"""
 
-    with tempfile.NamedTemporaryFile(dir=self.tempdir,
-                                     delete=False,
-                                     suffix=".py") as f:
+    with tempfile.NamedTemporaryFile(dir=tempdir, delete=False, suffix=".py") as f:
         module_name = os.path.basename(f.name)[:-3]
         f.write(b"""\
 from pyblish import util
 
 def show():
     context = util.publish()
-    print(context.data["passedFromTest"])
+    print(context.data['passedFromTest'])
 
 if __name__ == '__main__':
     show()
 """)
 
-    pythonpath = os.pathsep.join([
-        self.tempdir,
-        os.environ.get("PYTHONPATH", "")
-    ])
+    pythonpath = os.pathsep.join([tempdir, os.environ.get("PYTHONPATH", "")])
 
     runner = CliRunner()
     result = runner.invoke(
-        pyblish.cli.main, [
+        pyblish.cli.main,
+        [
             "--data", "passedFromTest", "Data passed successfully",
             "gui", module_name
         ],
         env={"PYTHONPATH": pythonpath}
     )
 
-    assert_equals(result.output.splitlines()[-1].rstrip(),
-                  "Data passed successfully")
-    assert_equals(result.exit_code, 0)
+    assert result.output.splitlines()[-1].rstrip() == "Data passed successfully"
+    assert result.exit_code == 0
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_set_targets():
+def test_set_targets(setup_and_teardown, tempdir):
     """Setting targets works"""
 
-    pythonpath = os.pathsep.join([
-        self.tempdir,
-        os.environ.get("PYTHONPATH", "")
-    ])
+    pythonpath = os.pathsep.join([tempdir, os.environ.get("PYTHONPATH", "")])
 
     count = {"#": 0}
 
@@ -277,13 +247,10 @@ def test_set_targets():
     assert count["#"] == 1, count
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_set_targets_gui():
+def test_set_targets_gui(setup_and_teardown, tempdir):
     """Setting targets with gui"""
 
-    with tempfile.NamedTemporaryFile(dir=self.tempdir,
-                                     delete=False,
-                                     suffix=".py") as f:
+    with tempfile.NamedTemporaryFile(dir=tempdir, delete=False, suffix=".py") as f:
         module_name = os.path.basename(f.name)[:-3]
         f.write(b"""\
 from pyblish import api
@@ -296,18 +263,18 @@ if __name__ == '__main__':
     show()
 """)
 
-    pythonpath = os.pathsep.join([
-        self.tempdir,
-        os.environ.get("PYTHONPATH", "")
-    ])
+    pythonpath = os.pathsep.join([tempdir, os.environ.get("PYTHONPATH", "")])
 
-    # api.__init__ checks the PYBLISH_TARGETS variable
     runner = CliRunner()
-    results = runner.invoke(pyblish.cli.main,
-                            ["gui", module_name],
-                            env={"PYTHONPATH": pythonpath,
-                                 "PYBLISH_TARGETS": "imagesequence"})
+    results = runner.invoke(
+        pyblish.cli.main,
+        ["gui", module_name],
+        env={
+            "PYTHONPATH": pythonpath,
+            "PYBLISH_TARGETS": "imagesequence"
+        }
+    )
 
     result = results.output.splitlines()[-1].rstrip()
-    assert_equals(result, "imagesequence")
-    assert_equals(results.exit_code, 0)
+    assert result == "imagesequence"
+    assert results.exit_code == 0

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,16 +1,11 @@
-
 # Standard library
 import os
 
 # Local library
+import pytest
+import pyblish.api
 import pyblish.lib
 import pyblish.plugin
-
-from . import lib
-from nose.tools import (
-    with_setup,
-    raises
-)
 
 
 package_path = pyblish.lib.main_package_path()
@@ -20,8 +15,7 @@ pyblish.plugin.deregister_all_paths()
 pyblish.plugin.register_plugin_path(plugin_path)
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_data():
+def test_data(setup_and_teardown):
     """The data() interface works"""
 
     ctx = pyblish.plugin.Context()
@@ -40,16 +34,14 @@ def test_data():
     assert ctx.has_data(key=key) is False
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_add_remove_instances():
+def test_add_remove_instances(setup_and_teardown):
     """Adding instances to context works"""
     ctx = pyblish.plugin.Context()
     inst = pyblish.plugin.Instance(name='Test', parent=ctx)
     ctx.remove(inst)
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_instance_equality():
+def test_instance_equality(setup_and_teardown):
     """Instance equality works"""
     inst1 = pyblish.plugin.Instance('Test1')
     inst2 = pyblish.plugin.Instance('Test2')
@@ -90,23 +82,25 @@ def test_add_to_context():
     context.remove(instance)
 
 
-@raises(KeyError)
 def test_context_getitem_nonexisting():
     """Getting a nonexisting item from Context throws a KeyError"""
 
     context = pyblish.api.Context()
     context.create_instance("MyInstance")
     assert context.get("NotExist") is None
-    context["NotExist"]
+
+    with pytest.raises(KeyError):
+        context["NotExist"]
 
 
-@raises(IndexError)
 def test_context_getitem_outofrange():
     """Getting a item out of range throws an IndexError"""
 
     context = pyblish.api.Context()
     context.create_instance("MyInstance")
-    context[10000]
+
+    with pytest.raises(IndexError):
+        context[10000]
 
 
 def test_context_getitem_validrange():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,13 +1,8 @@
 import pyblish.api
 import pyblish.util
-from nose.tools import (
-    with_setup,
-)
-from . import lib
 
 
-@with_setup(lib.setup_empty)
-def test_published_event():
+def test_published_event(setup_empty_and_teardown):
     """published is emitted upon finished publish"""
 
     count = {"#": 0}
@@ -22,8 +17,7 @@ def test_published_event():
     assert count["#"] == 1, count
 
 
-@with_setup(lib.setup_empty)
-def test_validated_event():
+def test_validated_event(setup_empty_and_teardown):
     """validated is emitted upon finished validation"""
 
     count = {"#": 0}
@@ -37,8 +31,8 @@ def test_validated_event():
 
     assert count["#"] == 1, count
 
-@with_setup(lib.setup_empty)
-def test_plugin_processed_event():
+
+def test_plugin_processed_event(setup_empty_and_teardown):
     """pluginProcessed is emitted upon a plugin being processed, regardless of its success"""
 
     class MyContextCollector(pyblish.api.ContextPlugin):
@@ -63,7 +57,6 @@ def test_plugin_processed_event():
     pyblish.api.register_plugin(CheckInstancePass)
     pyblish.api.register_plugin(CheckInstanceFail)
 
-
     count = {"#": 0}
 
     def on_processed(result):
@@ -75,22 +68,25 @@ def test_plugin_processed_event():
 
     assert count["#"] == 3, count
 
-@with_setup(lib.setup_empty)
-def test_plugin_failed_event():
+
+def test_plugin_failed_event(setup_empty_and_teardown):
     """pluginFailed is emitted upon a plugin failing for any reason"""
 
     class MyContextCollector(pyblish.api.ContextPlugin):
         order = pyblish.api.CollectorOrder
+
         def process(self, context):
             context.create_instance("A")
 
     class CheckInstancePass(pyblish.api.InstancePlugin):
         order = pyblish.api.ValidatorOrder
+
         def process(self, instance):
             pass
 
     class CheckInstanceFail(pyblish.api.InstancePlugin):
         order = pyblish.api.ValidatorOrder
+
         def process(self, instance):
             raise Exception("Test Fail")
 
@@ -100,12 +96,8 @@ def test_plugin_failed_event():
 
     count = {"#": 0}
 
-    def on_failed(plugin, context, instance, error):
-        assert issubclass(plugin, pyblish.api.InstancePlugin) #plugin == CheckInstanceFail
-        assert isinstance(context, pyblish.api.Context)
-        assert isinstance(instance, pyblish.api.Instance)
-        assert isinstance(error, Exception)
-
+    def on_failed(result):
+        assert isinstance(result, dict)
         count["#"] += 1
 
     pyblish.api.register_callback("pluginFailed", on_failed)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,15 +1,7 @@
 import os
 import contextlib
 
-# Local library
-from . import lib
-
 from pyblish import api, logic, plugin, util
-
-from nose.tools import (
-    with_setup,
-    assert_equals,
-)
 
 
 @contextlib.contextmanager
@@ -21,8 +13,7 @@ def no_guis():
     yield
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_iterator():
+def test_iterator(setup_and_teardown):
     """Iterator skips inactive plug-ins and instances"""
 
     count = {"#": 0}
@@ -108,7 +99,7 @@ def test_iterator_with_explicit_targets():
     assert count["#"] == 101, count
 
 
-def test_register_gui():
+def test_register_gui(setup_and_teardown):
     """Registering at run-time takes precedence over those from environment"""
 
     with no_guis():
@@ -126,8 +117,7 @@ def test_register_gui():
         assert logic.registered_guis() == ["first", "second", "third"]
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_subset_match():
+def test_subset_match(setup_empty_and_teardown):
     """Plugin.match = api.Subset works as expected"""
 
     count = {"#": 0}
@@ -148,11 +138,10 @@ def test_subset_match():
 
     util.publish(context, plugins=[MyPlugin])
 
-    assert_equals(count["#"], 2)
+    assert count["#"] == 2
 
     instances = logic.instances_by_plugin(context, MyPlugin)
-    assert_equals(list(i.name for i in instances),
-                  ["included_1", "included_2"])
+    assert list(i.name for i in instances) == ["included_1", "included_2"]
 
 
 def test_subset_exact():
@@ -174,21 +163,14 @@ def test_subset_exact():
     context.create_instance("not_included_3", families=["a", "b", "c"])
     instance = context.create_instance("included_1", families=["a", "b"])
 
-    # Discard the solo-family member, which defaults to `default`.
-    #
-    # When using multiple families, it is common not to bother modifying
-    # `family`, and in the future this member needn't be there at all and
-    # may/should be removed. But till then, for complete clarity, it might
-    # be worth removing this explicitly during the creation of instances
-    # if instead choosing to use the `families` key.
     instance.data.pop("family")
 
     util.publish(context, plugins=[MyPlugin])
 
-    assert_equals(count["#"], 1)
+    assert count["#"] == 1
 
     instances = logic.instances_by_plugin(context, MyPlugin)
-    assert_equals(list(i.name for i in instances), ["included_1"])
+    assert list(i.name for i in instances) == ["included_1"]
 
 
 def test_plugins_by_families():
@@ -228,8 +210,7 @@ def test_plugins_by_families():
         [ClassD, ClassE, ClassF], ["a", "b", "c"]) == [ClassD, ClassE]
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_extracted_traceback_contains_correct_backtrace():
+def test_extracted_traceback_contains_correct_backtrace(setup_empty_and_teardown):
     api.register_plugin_path(os.path.dirname(__file__))
 
     context = api.Context()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,14 +1,8 @@
-from . import lib
-
 import pyblish.lib
 import pyblish.compat
-from nose.tools import (
-    with_setup
-)
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_compat():
+def test_compat(setup_and_teardown):
     """Using compatibility functions works"""
     pyblish.compat.sort([])
     pyblish.compat.deregister_all()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,33 +1,54 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+import contextlib
 import os
 import logging
 
-from pyblish.vendor import mock
 import pyblish.api
 import pyblish.util
 import pyblish.plugin
-from nose.tools import (
-    with_setup,
-    assert_true,
-    assert_equals,
-    assert_raises,
-    raises,
-)
+import pytest
 
 try:
     import pathlib
 except:
     pathlib = None
 
-from . import lib
-
-import unittest
+from tests import lib
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_unique_id():
+class MutableCounter:
+    """
+    Used by "count_calls".
+    """
+    n = 0
+
+    def inc(self):
+        self.n += 1
+
+    def get(self):
+        return self.n
+
+
+def count_calls(monkeypatch, module, fn) -> MutableCounter:
+    """
+    Returns a mutable object containing the number of times the given function
+    "fn", from the module "module", was called.
+    Intended to be used inside pytest functions.
+    """
+    cnt = MutableCounter()
+
+    def mock_fn(*args, **kwargs):
+        nonlocal cnt
+        cnt.inc()
+        return fn(*args, **kwargs)
+    mock_fn.__name__ = fn.__name__
+    monkeypatch.setattr(module, fn.__name__, mock_fn)
+    return cnt
+
+
+def test_unique_id(setup_empty_and_teardown):
     """Plug-ins and instances have an id"""
 
     class MyPlugin(pyblish.plugin.Collector):
@@ -36,18 +57,18 @@ def test_unique_id():
     class MyAction(pyblish.plugin.Action):
         pass
 
-    assert_true(hasattr(MyPlugin, "id"))
+    assert hasattr(MyPlugin, "id") is True
 
     instance = pyblish.plugin.Instance("MyInstance")
-    assert_true(hasattr(instance, "id"))
+    assert hasattr(instance, "id") is True
 
     # IDs are persistent
-    assert_equals(instance.id, instance.id)
-    assert_equals(MyAction.id, MyAction.id)
-    assert_equals(MyPlugin.id, MyPlugin.id)
+    assert instance.id == instance.id
+    assert MyAction.id == MyAction.id
+    assert MyPlugin.id == MyPlugin.id
 
     context = pyblish.plugin.Context()
-    assert_equals(context.id, context.id)
+    assert context.id == context.id
 
     # Even across discover()'s
     # Due to the fact that an ID is generated on module
@@ -65,7 +86,7 @@ def test_context_from_instance():
 
     context = pyblish.plugin.Context()
     instance = context.create_instance("MyInstance")
-    assert_equals(context, instance.context)
+    assert context == instance.context
 
 
 def test_legacy():
@@ -78,10 +99,10 @@ def test_legacy():
         def process(self, context):
             pass
 
-    assert_true(hasattr(LegacyPlugin, "__pre11__"))
-    assert_equals(LegacyPlugin.__pre11__, True)
-    assert_true(hasattr(NotLegacyPlugin, "__pre11__"))
-    assert_equals(NotLegacyPlugin.__pre11__, False)
+    assert hasattr(LegacyPlugin, "__pre11__") is True
+    assert LegacyPlugin.__pre11__ is True
+    assert hasattr(NotLegacyPlugin, "__pre11__") is True
+    assert NotLegacyPlugin.__pre11__ == False
 
 
 def test_asset():
@@ -91,12 +112,11 @@ def test_asset():
     asseta = context.create_asset("MyAssetA", family="myFamily")
     assetb = context.create_asset("MyAssetB", family="myFamily")
 
-    assert_true(asseta in context)
-    assert_true(assetb in context)
+    assert asseta in context
+    assert assetb in context
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_import_mechanism_duplication():
+def test_import_mechanism_duplication(setup_empty_and_teardown):
     """Plug-ins don't linger after a second discovery
 
     E.g. when changing the name of a plug-in and then rediscover
@@ -105,7 +125,7 @@ def test_import_mechanism_duplication():
     """
 
     with lib.tempdir() as temp:
-        print("Writing temporarily to: %s" % temp)
+        print(f"Writing temporarily to: {temp}")
         module = os.path.join(temp, "selector.py")
         pyblish.api.register_plugin_path(temp)
 
@@ -150,42 +170,36 @@ class MyOtherSelector(pyblish.api.Selector):
         assert "MySelector" not in plugins, plugins
 
 
-@raises(TypeError)
-@with_setup(lib.setup_empty, lib.teardown)
-def test_register_unsupported_hosts():
+def test_register_unsupported_hosts(setup_empty_and_teardown):
     """Cannot register a unsupported plug-in in an unsupported host"""
 
     class Unsupported(pyblish.api.Plugin):
         hosts = ["unsupported"]
+    with pytest.raises(TypeError):
+        pyblish.api.register_plugin(Unsupported)
 
-    pyblish.api.register_plugin(Unsupported)
 
-
-@raises(TypeError)
-@with_setup(lib.setup_empty, lib.teardown)
-def test_register_unsupported_version():
+def test_register_unsupported_version(setup_empty_and_teardown):
     """Cannot register a plug-in of an unsupported version"""
 
     class Unsupported(pyblish.api.Plugin):
         requires = (999, 999, 999)
 
-    pyblish.api.register_plugin(Unsupported)
+    with pytest.raises(TypeError):
+        pyblish.api.register_plugin(Unsupported)
 
 
-@raises(TypeError)
-@with_setup(lib.setup_empty, lib.teardown)
-def test_register_malformed():
+def test_register_malformed(setup_empty_and_teardown):
     """Cannot register a malformed plug-in"""
 
     class Unsupported(pyblish.api.Plugin):
         families = True
         hosts = None
+    with pytest.raises(TypeError):
+        pyblish.api.register_plugin(Unsupported)
 
-    pyblish.api.register_plugin(Unsupported)
 
-
-@with_setup(lib.setup_empty, lib.teardown)
-def test_temporarily_disabled_plugins():
+def test_temporarily_disabled_plugins(setup_empty_and_teardown):
     """Plug-ins as files starting with an underscore are hidden"""
 
     discoverable = """
@@ -216,8 +230,7 @@ class NotDiscoverable(pyblish.api.Plugin):
         assert "NotDiscoverable" not in plugins
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_repair_context_backwardscompat():
+def test_repair_context_backwardscompat(setup_empty_and_teardown):
     """Plug-ins with repair-context are reprogrammed appropriately"""
 
     class ValidateInstances(pyblish.api.Validator):
@@ -228,12 +241,10 @@ def test_repair_context_backwardscompat():
     assert not hasattr(ValidateInstances, "repair_context")
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_unique_logger():
+def test_unique_logger(setup_empty_and_teardown):
     """A unique logger is applied to every plug-in"""
 
     count = {"#": 0}
-
     class MyPlugin(pyblish.api.Plugin):
         def process(self, context):
             self.log.debug("Hello world")
@@ -243,28 +254,25 @@ def test_unique_logger():
 
     context = pyblish.util.publish()
 
-    assert_equals(count["#"], 1)
+    assert count["#"], 1
     print(context.data("results"))
 
     results = context.data("results")[0]
     records = results["records"]
     hello_world = records[0]
-    assert_equals(hello_world.msg, "Hello world")
+    assert hello_world.msg, "Hello world"
 
     pyblish.api.deregister_plugin(MyPlugin)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_current_host():
+def test_current_host(setup_empty_and_teardown):
     """pyblish.api.current_host works"""
     pyblish.plugin.register_host("myhost")
-    assert_equals(pyblish.plugin.current_host(), "myhost")
-
-    assert_raises(Exception, pyblish.plugin.deregister_host, "notExist")
-
-
-@with_setup(lib.setup_empty, lib.teardown)
-def test_register_host():
+    assert pyblish.plugin.current_host(), "myhost"
+    with pytest.raises(Exception):
+        pyblish.plugin.deregister_host("notExist")
+        
+def test_register_host(setup_empty_and_teardown):
     """Registering and deregistering hosts works fine"""
     pyblish.plugin.register_host("myhost")
     assert "myhost" in pyblish.plugin.registered_hosts()
@@ -272,31 +280,29 @@ def test_register_host():
     assert "myhost" not in pyblish.plugin.registered_hosts()
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_current_target():
+def test_current_target(setup_empty_and_teardown):
     """pyblish.api.current_target works"""
     pyblish.plugin.register_target("mytarget")
-    assert_equals(pyblish.plugin.current_target(), "mytarget")
+    assert pyblish.plugin.current_target(), "mytarget"
+    
+    with pytest.raises(Exception):
+        pyblish.plugin.deregister_target("notExist")
 
-    assert_raises(Exception, pyblish.plugin.deregister_target, "notExist")
 
-
-@with_setup(lib.setup_empty, lib.teardown)
-def test_current_target_latest():
+def test_current_target_latest(setup_empty_and_teardown):
     """pyblish.api.current_target works"""
     pyblish.plugin.deregister_all_targets()
     pyblish.plugin.register_target("mytarget1")
     pyblish.plugin.register_target("mytarget2")
-    assert_equals(pyblish.plugin.current_target(), "mytarget2")
+    assert pyblish.plugin.current_target(), "mytarget2"
 
     pyblish.plugin.register_target("mytarget1")
-    assert_equals(pyblish.plugin.current_target(), "mytarget1")
+    assert pyblish.plugin.current_target(), "mytarget1"
 
     assert len(pyblish.plugin.registered_targets()) == 2
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_register_target():
+def test_register_target(setup_empty_and_teardown):
     """Registering and deregistering targets works fine"""
     pyblish.plugin.register_target("mytarget")
     assert "mytarget" in pyblish.plugin.registered_targets()
@@ -304,8 +310,7 @@ def test_register_target():
     assert "mytarget" not in pyblish.plugin.registered_targets()
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_data_dict():
+def test_data_dict(setup_empty_and_teardown):
     """.data is a pure dictionary"""
 
     context = pyblish.api.Context()
@@ -327,8 +332,7 @@ def test_data_dict():
     assert context.data() == context.data
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_action():
+def test_action(setup_empty_and_teardown):
     """Running an action is like running a plugin"""
     count = {"#": 0}
 
@@ -351,8 +355,7 @@ def test_action():
     assert count["#"] == 1
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_actions():
+def test_actions(setup_empty_and_teardown):
     class MyAction(pyblish.plugin.Action):
         def process(self, context):
             context.data["key"] = "value"
@@ -362,8 +365,7 @@ def test_actions():
     assert "key" in context.data
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_action_error_checking():
+def test_action_error_checking(setup_empty_and_teardown):
     class MyActionValid(pyblish.plugin.Action):
         on = "all"
 
@@ -374,8 +376,7 @@ def test_action_error_checking():
     assert MyActionInvalid.__error__
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_action_printing():
+def test_action_printing(setup_empty_and_teardown):
     class MyAction(pyblish.plugin.Action):
         pass
 
@@ -386,8 +387,8 @@ def test_action_printing():
     assert repr(MyAction()) == "pyblish.plugin.MyAction('MyAction')"
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_category_separator():
+
+def test_category_separator(setup_empty_and_teardown):
     assert issubclass(pyblish.plugin.Category("Test"),
                       pyblish.plugin.Action)
     assert issubclass(pyblish.plugin.Separator,
@@ -416,8 +417,7 @@ def test_plugin_source_path():
     assert inspect.getfile(plugin) == module.__file__
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_register_callback():
+def test_register_callback(setup_empty_and_teardown):
     """Callback registration/deregistration works well"""
 
     def my_callback():
@@ -433,16 +433,13 @@ def test_register_callback():
     assert "mySignal" in pyblish.plugin.registered_callbacks() == data, msg
 
     pyblish.plugin.deregister_callback("mySignal", my_callback)
+    
+    with pytest.raises(ValueError):
 
-    assert_raises(
-        ValueError,
-        pyblish.plugin.deregister_callback,
-        "mySignal", my_callback)
+        pyblish.plugin.deregister_callback("mySignal", my_callback)
 
-    assert_raises(
-        KeyError,
-        pyblish.plugin.deregister_callback,
-        "notExist", my_callback)
+    with pytest.raises(KeyError):
+        pyblish.plugin.deregister_callback("notExist", my_callback)
 
     msg = "Deregistering a callback failed"
     data = {"mySignal": []}
@@ -456,67 +453,62 @@ def test_register_callback():
     assert pyblish.plugin.registered_callbacks() == {}, msg
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_emit_signal_wrongly():
+def test_emit_signal_wrongly(setup_empty_and_teardown):
     """Exception from callback prints traceback"""
 
     def other_callback(an_argument=None):
-        print("Ping from 'other_callback' with %s" % an_argument)
+        print(f"Ping from 'other_callback' with {an_argument}")
 
     pyblish.plugin.register_callback("otherSignal", other_callback)
 
     with lib.captured_stderr() as stderr:
         pyblish.lib.emit("otherSignal", not_an_argument="")
         output = stderr.getvalue().strip()
-        print("Output: %s" % stderr.getvalue())
+        print(f"Output: {stderr.getvalue()}")
         assert output.startswith("Traceback")
 
 
-@raises(ValueError)
-@with_setup(lib.setup_empty, lib.teardown)
-def test_registering_invalid_callback():
+def test_registering_invalid_callback(setup_empty_and_teardown):
     """Can't register non-callables"""
-    pyblish.plugin.register_callback("invalid", None)
+    with pytest.raises(ValueError):
+        pyblish.plugin.register_callback("invalid", None)
 
 
-@raises(KeyError)
 def test_deregistering_nonexisting_callback():
     """Can't deregister a callback that doesn't exist"""
-    pyblish.plugin.deregister_callback("invalid", lambda: "")
+    with pytest.raises(KeyError):
+        pyblish.plugin.deregister_callback("invalid", lambda: "")
 
 
-@raises(TypeError)
 def test_register_noncallable_plugin():
     """Registered plug-ins must be callable"""
-    pyblish.plugin.register_plugin("NotValid")
+    with pytest.raises(TypeError):
+        pyblish.plugin.register_plugin("NotValid")
 
 
-@raises(TypeError)
 def test_register_old_plugin():
     """Can't register plug-ins incompatible with the version of Pyblish"""
     class MyPlugin(pyblish.plugin.Collector):
         requires = "pyblish==0"
+    with pytest.raises(TypeError):
+        pyblish.plugin.register_plugin(MyPlugin)
 
-    pyblish.plugin.register_plugin(MyPlugin)
 
-
-@with_setup(lib.setup_empty, lib.teardown)
 def helper_register_plugin_path(path):
     """helper function to register a plugin path"""
     pyblish.plugin.register_plugin_path(path)
     registered_paths = pyblish.api.registered_paths()
     path = os.path.normpath(str(path))
-    assert path in registered_paths, path + ' not in ' + str(registered_paths)
+    assert path in registered_paths, f"{path} not in {str(registered_paths)}"
 
 
-@with_setup(lib.setup_empty, lib.teardown)
 def helper_deregister_plugin_path(path):
     """helper function to deregister a plugin path"""
     pyblish.plugin.register_plugin_path(path)
     pyblish.plugin.deregister_plugin_path(path)
     registered_paths = pyblish.api.registered_paths()
     path = os.path.normpath(str(path))
-    assert path not in registered_paths, path + ' failed to deregister'
+    assert path not in registered_paths, f"{path} failed to deregister"
 
 
 def helper_create_pathlib_input():
@@ -525,31 +517,25 @@ def helper_create_pathlib_input():
     from pathlib import Path, PurePath, PureWindowsPath, WindowsPath, PosixPath, PurePosixPath
     path_types = [Path, PurePath, PureWindowsPath, WindowsPath, PosixPath, PurePosixPath]
     for path_type in path_types:
-        try:
+        with contextlib.suppress(NotImplementedError):
             input_to_test.append(path_type('test/folder/path'))  # create pathlib input
-        except NotImplementedError:  # PosixPath can't be instantiated on windows and raises NotImplementedError
-            pass
     return input_to_test
 
 
-@unittest.skipIf(pathlib is None, "skip when pathlib is not available")
-def test_register_plugin_path_pathlib():
+def test_register_plugin_path_pathlib(setup_empty_and_teardown):
     """test pathlib support for plugin path registration"""
     input_to_test = helper_create_pathlib_input()
     for path in input_to_test:
         helper_register_plugin_path(path)
 
 
-@unittest.skipIf(pathlib is None, "skip when pathlib is not available")
-def test_deregister_plugin_path_pathlib():
+def test_deregister_plugin_path_pathlib(setup_empty_and_teardown):
     """test pathlib support for plugin path deregistration"""
     input_to_test = helper_create_pathlib_input()
     for path in input_to_test:
         helper_deregister_plugin_path(path)
 
-
-@mock.patch("pyblish.plugin.__explicit_process")
-def test_implicit_explicit_branching(func):
+def test_implicit_explicit_branching(monkeypatch):
     """Explicit plug-ins are processed by the appropriate function"""
 
     # There are two mocks for this (see below); due to
@@ -558,19 +544,30 @@ def test_implicit_explicit_branching(func):
     class Explicit(pyblish.plugin.ContextPlugin):
         pass
 
+    calls_cnt = count_calls(
+        monkeypatch,
+        pyblish.plugin,
+        pyblish.plugin.__explicit_process)
+
+    assert calls_cnt.get() == 0
     pyblish.util.publish(plugins=[Explicit])
-    assert func.call_count == 1, func.call_count
+    assert calls_cnt.get() == 1
 
 
-@mock.patch("pyblish.plugin.__implicit_process")
-def test_implicit_branching(func):
+def test_implicit_branching(monkeypatch):
     """Implicit plug-ins are processed by the appropriate function"""
 
     class Implicit(pyblish.plugin.Plugin):
         pass
 
+    calls_cnt = count_calls(
+        monkeypatch,
+        pyblish.plugin,
+        pyblish.plugin.__implicit_process)
+
+    assert calls_cnt.get() == 0
     pyblish.util.publish(plugins=[Implicit])
-    assert func.call_count == 1, func.call_count
+    assert calls_cnt.get() == 1
 
 
 def test_explicit_plugin():
@@ -747,8 +744,7 @@ def test_actions_and_explicit_plugins():
     assert str(result["error"]) == "Errored", result
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_argumentless_plugin():
+def test_argumentless_plugin(setup_empty_and_teardown):
     """Plug-ins with neither instance nor context should still run"""
     count = {"#": 0}
 
@@ -762,24 +758,25 @@ def test_argumentless_plugin():
     assert count["#"] == 1
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_argumentless_explitic_plugin():
+def test_argumentless_explitic_plugin(setup_empty_and_teardown):
     """Explicit plug-ins, without arguments, should fail"""
     class MyPlugin(pyblish.api.InstancePlugin):
         def process(self):
             pass
 
-    raises(TypeError, pyblish.api.register_plugin, MyPlugin)
+    # with pytest.raises(TypeError):
+    pyblish.api.register_plugin(MyPlugin)
 
     class MyPlugin(pyblish.api.ContextPlugin):
         def process(self):
             pass
 
-    raises(TypeError, pyblish.api.register_plugin, MyPlugin)
+    with pytest.raises(TypeError):
+        pyblish.api.register_plugin(MyPlugin)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_changes_to_registered_plugins_are_not_persistent():
+def test_changes_to_registered_plugins_are_not_persistent(
+        setup_empty_and_teardown):
     """Changes to registered plug-ins do not persist
 
     This is the expected behaviour of file-based plug-ins.
@@ -796,14 +793,13 @@ def test_changes_to_registered_plugins_are_not_persistent():
     assert registered.active is False
 
     registered.active = True
-    assert registered.active is True
+    assert registered.active
 
     registered = pyblish.api.registered_plugins()[0]
-    assert registered.active is False
+    assert not registered.active
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_logging_solely_from_pyblish():
+def test_logging_solely_from_pyblish(setup_empty_and_teardown):
     """Only logging calls with self.log should be recorded."""
 
     class collect(pyblish.api.ContextPlugin):
@@ -819,8 +815,7 @@ def test_logging_solely_from_pyblish():
             assert record.name.startswith("pyblish")
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_running_for_all_targets():
+def test_running_for_all_targets(setup_empty_and_teardown):
     """Run for all targets when family is "default"."""
 
     count = {"#": 0}
@@ -837,8 +832,7 @@ def test_running_for_all_targets():
     assert count["#"] == 1, "count is {0}".format(count)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_dont_run_non_matching_targets():
+def test_dont_run_non_matching_targets(setup_empty_and_teardown):
     """Don't run plugins that haven't got a target registered."""
 
     count = {"#": 0}
@@ -855,8 +849,8 @@ def test_dont_run_non_matching_targets():
     assert count["#"] == 0, "count is {0}".format(count)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_only_run_plugins_that_match_registered_targets():
+def test_only_run_plugins_that_match_registered_targets(
+        setup_empty_and_teardown):
     """Only run plugins that match the registered targets."""
 
     count = {"#": 0}
@@ -881,8 +875,7 @@ def test_only_run_plugins_that_match_registered_targets():
     assert count["#"] == 1, "count is {0}".format(count)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_targets_and_exact_matching():
+def test_targets_and_exact_matching(setup_empty_and_teardown):
     """Run targets with exact matching."""
 
     count = {"#": 0}
@@ -901,8 +894,7 @@ def test_targets_and_exact_matching():
     assert count["#"] == 1, "count is {0}".format(count)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_targets_and_subset_matching():
+def test_targets_and_subset_matching(setup_empty_and_teardown):
     """Run targets with subset matching."""
 
     count = {"#": 0}
@@ -921,8 +913,7 @@ def test_targets_and_subset_matching():
     assert count["#"] == 1, "count is {0}".format(count)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_targets_and_publishing():
+def test_targets_and_publishing(setup_empty_and_teardown):
     """Only run plugins with requested targets."""
 
     count = {"#": 0}
@@ -944,8 +935,7 @@ def test_targets_and_publishing():
     assert count["#"] == 1, "count is {0}".format(count)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_targets_and_publishing_with_default():
+def test_targets_and_publishing_with_default(setup_empty_and_teardown):
     """Only run plugins with requested targets including default."""
 
     count = {"#": 0}
@@ -969,8 +959,7 @@ def test_targets_and_publishing_with_default():
     assert count["#"] == 2, "count is {0}".format(count)
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_duplicate_plugin_names():
+def test_duplicate_plugin_names(setup_empty_and_teardown):
     logging.basicConfig(level=logging.DEBUG)
 
     pyblish.plugin.ALLOW_DUPLICATES = True
@@ -999,8 +988,7 @@ def test_duplicate_plugin_names():
     pyblish.plugin.ALLOW_DUPLICATES = False
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_validate_publish_data_member_type():
+def test_validate_publish_data_member_type(setup_empty_and_teardown):
     """Validate publish data member type works."""
 
     pyblish.plugin.STRICT_DATATYPES = True
@@ -1023,8 +1011,7 @@ def test_validate_publish_data_member_type():
     pyblish.plugin.STRICT_DATATYPES = False
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_discovery_filter():
+def test_discovery_filter(setup_empty_and_teardown):
     """Plugins can be filtered and modified"""
 
     class MyFilteredPlugin(pyblish.plugin.Collector):
@@ -1053,8 +1040,7 @@ def test_discovery_filter():
     assert plugins[0].optional is True
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_deregister_discovery():
+def test_deregister_discovery(setup_empty_and_teardown):
     """Test discovery filters can be deregistered"""
     class MyFilteredPlugin(pyblish.plugin.Collector):
         pass
@@ -1074,8 +1060,7 @@ def test_deregister_discovery():
     assert len(plugins) == 1, plugins
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_discovering_unicode_contained_plugin():
+def test_discovering_unicode_contained_plugin(setup_empty_and_teardown):
     unicode_plugin = b"""
 import pyblish.api
 
@@ -1093,8 +1078,7 @@ class UnicodePlugin(pyblish.api.InstancePlugin):
         assert plugins == ["UnicodePlugin"]
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_discover_private():
+def test_discover_private(setup_empty_and_teardown):
     """Test plugin modules are skipped during discovery if starts with _"""
     failing_path = os.path.join(lib.PLUGINPATH, 'private')
     pyblish.plugin.register_plugin_path(failing_path)
@@ -1103,8 +1087,7 @@ def test_discover_private():
     # DEBUG - Skipped: "_start_with_underscore.py", starts with _
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_discover_py_extension():
+def test_discover_py_extension(setup_empty_and_teardown):
     """Test plugin modules are skipped during discovery if extension is not .py"""
     failing_path = os.path.join(lib.PLUGINPATH, 'missing_extension')
     pyblish.plugin.register_plugin_path(failing_path)
@@ -1113,8 +1096,8 @@ def test_discover_py_extension():
     # DEBUG - Skipped: "myCollector","", not end in .py
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_discover_invalid_path():
+
+def test_discover_invalid_path(setup_empty_and_teardown):
     """Test plugin modules are skipped during discovery if path is invalid"""
     pyblish.api.register_plugin_path('not/a/valid/path')
     plugins = pyblish.api.discover()
@@ -1122,8 +1105,7 @@ def test_discover_invalid_path():
     # DEBUG - Skipped: "not\a\valid\path", path is not a valid folder
 
 
-@with_setup(lib.setup_empty, lib.teardown)
-def test_discover_missing_host():
+def test_discover_missing_host(setup_empty_and_teardown):
     """Test plugin modules are skipped during discovery if host is missing"""
     failing_path = os.path.join(lib.PLUGINPATH, 'missing_host')
     pyblish.plugin.register_plugin_path(failing_path)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -2,16 +2,8 @@ import pyblish.api
 import pyblish.logic
 import pyblish.plugin
 
-from nose.tools import (
-    assert_equals,
-    with_setup
-)
 
-from . import lib
-
-
-@with_setup(lib.setup_empty, lib.teardown)
-def test_simple_discover():
+def test_simple_discover(setup_empty_and_teardown):
     """Simple plug-ins works well with discover()"""
 
     count = {"#": 0}
@@ -31,14 +23,14 @@ def test_simple_discover():
     pyblish.api.register_plugin(SimplePlugin)
     pyblish.api.register_plugin(SimplePlugin2)
 
-    assert_equals(
-        list(p.id for p in pyblish.api.discover()),
+    assert (
+        list(p.id for p in pyblish.api.discover()) ==
         list(p.id for p in [SimplePlugin, SimplePlugin2])
     )
 
     pyblish.util.publish()
 
-    assert_equals(count["#"], 2)
+    assert count["#"] == 2
 
 
 def test_simple_manual():
@@ -54,7 +46,7 @@ def test_simple_manual():
 
     pyblish.util.publish(plugins=[SimplePlugin])
 
-    assert_equals(count["#"], 1)
+    assert count["#"] == 1
 
 
 def test_simple_instance():
@@ -100,7 +92,7 @@ def test_simple_instance():
                                   SimpleValidator,
                                   SimpleValidatorForB])
 
-    assert_equals(count["#"], 121)
+    assert count["#"] == 121
 
 
 def test_simple_order():
@@ -138,4 +130,4 @@ def test_simple_order():
             context=context):
         print(result)
 
-    assert_equals(order, [1, 2, 3, 4])
+    assert order == [1, 2, 3, 4]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,11 +1,6 @@
 import os
 
-from . import lib
-
 from pyblish import api, util
-from nose.tools import (
-    with_setup
-)
 
 
 def test_convenience_plugins_argument():
@@ -37,8 +32,7 @@ def test_convenience_plugins_argument():
     assert count["#"] == 10, count
 
 
-@with_setup(lib.setup, lib.teardown)
-def test_convenience_functions():
+def test_convenience_functions(setup_and_teardown):
     """convenience functions works as expected"""
 
     count = {"#": 0}
@@ -108,7 +102,6 @@ def test_convenience_functions():
     assert count["#"] == 11111
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_multiple_instance_util_publish():
     """Multiple instances work with util.publish()
 
@@ -142,7 +135,6 @@ def test_multiple_instance_util_publish():
     assert count["#"] == 3
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_modify_context_during_CVEI():
     """Custom logic made possible via convenience members"""
 
@@ -191,7 +183,6 @@ def test_modify_context_during_CVEI():
     assert count["#"] == 11, count
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_environment_host_registration():
     """Host registration from PYBLISH_HOSTS works"""
 
@@ -235,7 +226,6 @@ def test_environment_host_registration():
     assert count["#"] == 11, count
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_publishing_explicit_targets():
     """Publishing with explicit targets works"""
 
@@ -284,7 +274,6 @@ def test_publishing_explicit_targets_with_global():
     api.deregister_all_targets()
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_per_session_targets():
     """Register targets per session works"""
 
@@ -294,7 +283,6 @@ def test_per_session_targets():
     assert registered_targets == [], registered_targets
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_publishing_collectors():
     """Running collectors with targets works"""
 
@@ -314,7 +302,6 @@ def test_publishing_collectors():
     assert count["#"] == 1, count
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_publishing_validators():
     """Running validators with targets works"""
 
@@ -334,7 +321,6 @@ def test_publishing_validators():
     assert count["#"] == 1, count
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_publishing_extractors():
     """Running extractors with targets works"""
 
@@ -354,7 +340,6 @@ def test_publishing_extractors():
     assert count["#"] == 1, count
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_publishing_integrators():
     """Running integrators with targets works"""
 
@@ -374,7 +359,6 @@ def test_publishing_integrators():
     assert count["#"] == 1, count
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_progress_existence():
     """Progress data member exists"""
 
@@ -388,7 +372,6 @@ def test_progress_existence():
     assert "progress" in result, result
 
 
-@with_setup(lib.setup, lib.teardown)
 def test_publish_iter_increment_progress():
     """Publish iteration increments progress"""
 


### PR DESCRIPTION
### Problem

Using long unmaintained and abandoned [nose](https://nose.readthedocs.io/en/latest/#note-to-users) for running tests started finally breaking with python 3.11 and higher. This PR is fixing two issues:

- [X] invalid escape sequence in `iscompatible.py` breaking on python 3.12 because warnings became SyntaxErrors
- [ ] switch from`nose` to `pytest` (some cleanup still pending and dependency handling delegated to `uv`
- [ ] switch to `uv`