### PR TITLE
Remove invalid escape sequence 

### DIFF
--- a/pyblish/vendor/iscompatible.py
+++ b/pyblish/vendor/iscompatible.py
@@ -2,7 +2,7 @@
 Python versioning with requirements.txt syntax
 ==============================================
 
-iscompatible v\ |version|. gives you the power of the pip requirements.txt
+iscompatible v |version|. gives you the power of the pip requirements.txt
 syntax for everyday python packages, modules, classes or arbitrary
 functions.
 


### PR DESCRIPTION
## Change

Remove invalid escape sequence in docstring causing `SyntaxError`s on Python 3.12. This is taken out from https://github.com/pyblish/pyblish-base/pull/408 